### PR TITLE
CSE-434 Implement tests for SPIFlashFileSystem library

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,6 +317,12 @@ If you attempt to open an existing file with *mode* = `"w"`, a `SPIFlashFileSyst
 
 If you attempt to open a file with a mode other than `"r"` or `"w"` a `SPIFlashFileSystem.ERR_UNKNOWN_MODE` error will be thrown.
 
+If you create an empty file then it will be stored in cache only and disappear on next reboot.
+```squirrel
+// create an empty file
+sffs.open("filename.txt", "w").close();
+```
+
 ### eraseAll()
 
 The *eraseAll()* method erases the portion of the SPI Flash allocated to the filesystem.

--- a/SPIFlashFileSystem.class.nut
+++ b/SPIFlashFileSystem.class.nut
@@ -123,10 +123,11 @@ class SPIFlashFileSystem {
         if (!_fat.fileExists(fname)) throw ERR_FILE_NOT_FOUND;
         if (isFileOpen(fname)) throw ERR_OPEN_FILE;
 
-        _enable();
-
         // Build a blob to zero out the file
         local zeros = blob(SPIFLASHFILESYSTEM_HEADER_SIZE + SPIFLASHFILESYSTEM_TIMESTAMP_SIZE + SPIFLASHFILESYSTEM_MAX_FNAME_SIZE + 1);
+
+        _enable();
+
         local pages = _fat.forEachPage(fname, function(addr) {
             // Erase the page headers
             local res = _flash.write(addr, zeros, SPIFLASHFILESYSTEM_SPIFLASH_VERIFY);
@@ -149,21 +150,21 @@ class SPIFlashFileSystem {
 
     // Erases all files
     function eraseFiles() {
-        
+
         if (_openFiles.len() > 0) return server.error("Can't call eraseFiles() with open files");
 
         _enable();
-        
+
         local files_to_erase = _fat.getFileList();
         foreach (file in files_to_erase) {
             eraseFile(file.fname);
         }
 
         _disable();
-        
+
     }
-    
-    
+
+
     // Opens a file to (r)ead, (w)rite, or (a)ppend
     function open(fname, mode) {
     	// Validate filename
@@ -215,7 +216,7 @@ class SPIFlashFileSystem {
         return { "size": _size, "len": _len, "start": _start, "end": _end, "pages": _pages }
     }
 
-    // Returns the created time stamp 
+    // Returns the created time stamp
     function created(fileRef) {
         return _fat.get(fileRef).created;
     }
@@ -224,7 +225,7 @@ class SPIFlashFileSystem {
 
         // Smaller files have more overhead than larger files so its impossible to know exactly how much space is free.
         // This is a total guess of how much space an average sector would have for data.
-        local stats = _fat.getStats();        
+        local stats = _fat.getStats();
         const page_size_guess = 4000;
         local free = stats.free * page_size_guess;
         local freeable = (stats.free + stats.erased) * page_size_guess;
@@ -578,7 +579,8 @@ class SPIFlashFileSystem {
 
         // Correct the size
         local maxSize = SPIFLASHFILESYSTEM_PAGE_SIZE - headerBlob.tell();
-        if ((pageData.span != 0xFFFF) && (pageData.size == 0 || pageData.size > maxSize)) {
+        if ((pageData.span != 0xFFFF && pageData.id != 0)
+           && (pageData.size == 0 || pageData.size > maxSize)) {
             pageData.size = maxSize;
         }
         pageData.eof <- headerBlob.tell() + pageData.size;
@@ -792,7 +794,7 @@ class SPIFlashFileSystem.FAT {
             });
         }
 
-        // Order the files 
+        // Order the files
         if (orderByDate) {
             list.sort(function(a, b) { return a.created <=> b.created }.bindenv(this));
         } else {
@@ -1027,7 +1029,8 @@ class SPIFlashFileSystem.File {
     function read(len = null) {
         local data = _filesystem._read(_fileId, _pos, len);
         _pos += data.len();
-
+        // make data blob ready to read
+        data.seek(0);
         return data;
     }
 

--- a/tests/BaseSFFS.device.nut
+++ b/tests/BaseSFFS.device.nut
@@ -1,0 +1,110 @@
+// MIT License
+//
+// Copyright 2017 Electric Imp
+//
+// SPDX-License-Identifier: MIT
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO
+// EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES
+// OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+// ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+// "Promise" symbol is injected dependency from ImpUnit_Promise module,
+// while class being tested can be accessed from global scope as "::Promise".
+
+// Base class for the SFFS test cases
+// to share common functionality
+class BaseSffsTestCase extends ImpTestCase {
+
+  size = 0;
+  sffs = null;
+  pages = 0;
+  start = 0;
+
+  //
+  // Initialization of the SpiFlashFileSystem library
+  //  - create an SpiFlashFileSystem class object
+  //  - erase all SPI flash data
+  //  - initialize a new FAT block
+  function setUp() {
+    return Promise(function(ok, err) {
+      // check that we're on  003+
+
+      this.assertTrue("spiflash" in hardware, "imp003 and above is expected");
+
+      // get actual flash size
+      hardware.spiflash.enable();
+      this.size = hardware.spiflash.size();
+      hardware.spiflash.disable();
+      // number of the available pages
+      this.pages = this.size / 4096;
+
+      // init sffs
+      this.sffs = SPIFlashFileSystem(0, size);
+      this.sffs.eraseAll();
+      this.sffs.init(function(v) {
+        this.start = this.sffs.dimensions().start;
+
+        ok("Have " + this.size.tofloat() / 1024 + "KB of flash available")
+
+        this.setUpParameters();
+
+      }.bindenv(this));
+
+    }.bindenv(this));
+  }
+
+  //
+  // Stub method to overwite in the inherited class
+  //
+  function setUpParameters() {
+    // Empty
+  }
+
+  //
+  // Create an empty file or file with payload
+  //
+  function createFile(filename, payload = null) {
+    local file = sffs.open(filename, "w");
+    if (payload)
+      file.write(payload);
+    file.close();
+  }
+
+  //
+  // Make a bad page on flash by addr
+  // if addr is null use any free page
+  //
+  function makeBadPage(addr = null) {
+    local page = (addr == null ? sffs._fat.getFreePage() : addr);
+    local header = blob(10);
+    header.writen(0, 'w'); // id is 0
+    header.writen(0, 'w'); // span is 0
+    header.writen(123, 'w'); // size is not null
+
+    sffs._enable();
+    // Erase the page headers
+    local res = sffs._flash.write(page, header, SPIFLASHFILESYSTEM_SPIFLASH_VERIFY);
+    sffs._disable();
+  }
+
+  //
+  // Erase flash on test case completion
+  //
+  function tearDown() {
+    this.sffs.eraseAll();
+    return "Flash erased";
+  }
+}

--- a/tests/BaseSFFS.device.nut
+++ b/tests/BaseSFFS.device.nut
@@ -44,7 +44,10 @@ class BaseSffsTestCase extends ImpTestCase {
         return Promise(function(ok, err) {
             // check that we're on    003+
 
-            assertTrue("spiflash" in hardware, "imp003 and above is expected");
+            if (!("spiflash" in hardware)) {
+                err("imp003 and above is expected");
+                return;
+            }
 
             // get actual flash size
             hardware.spiflash.enable();

--- a/tests/SFFS.device.test.nut
+++ b/tests/SFFS.device.test.nut
@@ -1,247 +1,260 @@
-/**
-  * Test case to test SPIFlashFileSystem funstionality
-  *
-  * Currently this test case expects Amy board with 4-mbit flash chip
-  * todo: use SPIFlash library for 001/002
-  */
+// MIT License
+//
+// Copyright 2017 Electric Imp
+//
+// SPDX-License-Identifier: MIT
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO
+// EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES
+// OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+// ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+// "Promise" symbol is injected dependency from ImpUnit_Promise module,
+// while class being tested can be accessed from global scope as "::Promise".
 
-class SFFSTestCase extends ImpTestCase {
+@include __PATH__ + "/BaseSFFS.device.nut"
 
-    size = 0;
-    sffs = null;
+class SFFSTestCase extends BaseSffsTestCase {
 
-    /**
-     * Init SFFS
-     *  - create class
-     *  - erase flash
-     *  - init FAT
-     */
-    function setUp() {
-        return Promise(function(ok, err) {
-            // check that we're on  003+
+  //
+  // Test .fileList() with empty FAT
+  //
+  function test01_FileListWhenEmpty() {
+    // chekc that nothing is listed yet
+    local files = this.sffs.getFileList();
+    this.assertTrue(type(files) == "array");
+    this.assertEqual(0, files.len());
+  }
 
-            this.assertTrue("spiflash" in hardware, "imp003 and above is expected");
+  //
+  //Test .fileList() after cteating a file
+  //
+  function test02_FileListNonEmpty() {
+    // create an empty file
+    createFile("file1.txt");
 
-            // get actual flash size
-            hardware.spiflash.enable();
-            this.size = hardware.spiflash.size();
-            hardware.spiflash.disable();
+    // check that it's listed
+    local files = this.sffs.getFileList();
+    this.assertTrue(type(files) == "array");
+    this.assertEqual(1, files.len());
 
-            // init sffs
-            this.sffs = SPIFlashFileSystem(0, size);
-            this.sffs.eraseAll();
-            this.sffs.init(function (v) {
-                ok("Have " + this.size.tofloat() / 1024 + "KB of flash available")
-            }.bindenv(this));
+    // check creation date
+    this.assertClose(time(), files[0].created, 1);
 
-        }.bindenv(this));
+    // check the rest of the files data structure
+    files[0]["created"] <- 0;
+    this.assertDeepEqual([{
+      "size": 0,
+      "id": 1,
+      "created": 0,
+      "fname": "file1.txt"
+    }], files);
+  }
+
+  //
+  //Test ordering of files in .fileList()
+  //
+  function test03_FileListOrdering() {
+    return Promise(function(ok, err) {
+      imp.wakeup(2, function() {
+        try {
+          // creat file a with later date, but alphabetically
+          // preceedeing already existing file1.txt
+          this.sffs.open("file0.txt", "w").close();
+
+          local files;
+
+          // list filres with ordering by name, adc
+          files = this.sffs.getFileList( /* orderByDate=false */ );
+          this.assertEqual("file0.txt", files[0].fname, "getFileList(false) is expected to sort files by name");
+
+          // list files ordering by date, asc
+          files = this.sffs.getFileList(true /* orderByDate=true */ );
+          this.assertEqual("file1.txt", files[0].fname, "getFileList(true) is expected to sort files by creation date");
+          ok();
+
+        } catch (e) {
+          err(e);
+        }
+      }.bindenv(this));
+    }.bindenv(this));
+  }
+
+  //
+  //Test .fileExists()
+  //
+  function test04_fileExists() {
+    this.assertEqual(true, this.sffs.fileExists("file1.txt"));
+    this.assertEqual(false, this.sffs.fileExists("nonexisting-file.txt"));
+    this.assertEqual(false, this.sffs.fileExists(""));
+    this.assertEqual(false, this.sffs.fileExists("\0"));
+  }
+
+  //
+  //Test .fileSize()
+  //
+  function test05_fileSize() {
+    // empty file
+    this.assertEqual(0, this.sffs.fileSize("file1.txt"));
+
+    // nonexistent file
+    this.assertThrowsError(function() {
+      this.sffs.fileSize("nonexisting-file.txt");
+    }, this);
+
+    // create file
+    local f = this.sffs.open("file2.txt", "w");
+    f.write(blob(100))
+    f.close();
+
+    // check existing file size
+    this.assertEqual(100, this.sffs.fileSize("file2.txt"));
+  }
+
+  //
+  //Test .isFileOpen()
+  //
+  function test06_isFileOpen() {
+    // existing closed file
+    this.assertEqual(false, this.sffs.isFileOpen("file1.txt"));
+
+    // non-existing file
+    this.assertThrowsError(function() {
+      this.sffs.isFileOpen("nonexisting-file.txt");
+    }, this);
+
+    // open file
+    local f = this.sffs.open("file2.txt", "r");
+    this.assertEqual(true, this.sffs.isFileOpen("file2.txt"));
+    f.close();
+  }
+
+  //
+  //Test .open()
+  //
+  function test07_Open() {
+    local f;
+
+    // existing file for reading
+    f = this.sffs.open("file1.txt", "r");
+    this.assertTrue(f instanceof SPIFlashFileSystem.File);
+    f.close();
+
+    // non-existing file for reading
+    this.assertThrowsError(function() {
+      this.sffs.open("nonexisting-file.txt", "r");
+    }, this);
+
+    // existing file for writing
+    this.assertThrowsError(function() {
+      this.sffs.open("file1.txt", "w");
+    }, this);
+
+    // non-existing file for writing
+    f = this.sffs.open("file3.txt", "w");
+    this.assertTrue(f instanceof SPIFlashFileSystem.File);
+    this.assertTrue(this.sffs.isFileOpen("file3.txt"));
+    f.close();
+  }
+
+  //
+  //Test .eraseFile()
+  //
+  function test08_EraseFile() {
+    // existing file
+    this.sffs.eraseFile("file1.txt");
+    this.assertEqual(false, this.sffs.fileExists("file1.txt"));
+
+    // non-existing file
+    this.assertThrowsError(function() {
+      this.sffs.eraseFile("nonexisting-file.txt");
+    }, this);
+
+    // existing open file
+    local f = this.sffs.open("file2.txt", "r");
+    this.assertThrowsError(@() this.sffs.eraseFile("file2.txt"), this);
+    this.assertEqual(true, this.sffs.fileExists("file2.txt"));
+    f.close();
+  }
+
+  //
+  //Test .eraseFiles()
+  //
+  function test09_EraseFiles() {
+    local files;
+
+    // check that there are files
+    files = this.sffs.getFileList();
+    this.assertGreater(files.len(), 0);
+
+    // erase all files
+    this.sffs.eraseFiles();
+
+    // check that tere are no files
+    files = this.sffs.getFileList();
+    this.assertEqual(0, files.len());
+  }
+
+  //
+  //Test .dimensions()
+  //
+  function test10_Dimensions() {
+    this.assertDeepEqual({
+        "start": 0,
+        "size": this.size,
+        "end": this.size,
+        "len": this.size,
+        "pages": this.size / SPIFLASHFILESYSTEM_PAGE_SIZE
+      },
+      this.sffs.dimensions()
+    );
+  }
+
+  //
+  //Test .created()
+  //
+  function test11_Created() {
+    // test that created date on newly created file == time()
+    this.sffs.open("file4.txt", "w").close();
+    this.assertClose(time(), this.sffs.created("file4.txt"), 1);
+  }
+
+  //
+  // Helper method to test filename input parameters
+  //
+  function _openTest(filename) {
+    try {
+      sffs.open(null, "w");
+      assertTrue(false, "An ERR_INVALID_FILE ex")
+    } catch (e) {
+      assertEqual("Invalid filename", e);
     }
+  }
 
-    /**
-     * Test .fileList() with empty FAT
-     */
-    function test01_FileListWhenEmpty() {
-        // chekc that nothing is listed yet
-        local files = this.sffs.getFileList();
-        this.assertTrue(type(files) == "array");
-        this.assertEqual(0, files.len());
-    }
-
-    /**
-     * Test .fileList() after cteating a file
-     */
-    function test02_FileListNonEmpty() {
-        // create empty file
-        this.sffs.open("file1.txt", "w").close();
-
-        // check that it's listed
-        local files = this.sffs.getFileList();
-        this.assertTrue(type(files) == "array");
-        this.assertEqual(1, files.len());
-
-        // check creation date
-        this.assertClose(time(), files[0].created, 1);
-
-        // check the rest of the files data structure
-        files[0]["created"] <- 0;
-        this.assertDeepEqual([{"size":0,"id":1,"created":0,"fname":"file1.txt"}], files);
-    }
-
-    /**
-     * Test ordering of files in .fileList()
-     */
-    function test03_FileListOrdering() {
-        return Promise(function(ok, err) {
-            imp.wakeup(2, function() {
-                try {
-                    // creat file a with later date, but alphabetically
-                    // preceedeing already existing file1.txt
-                    this.sffs.open("file0.txt", "w").close();
-
-                    local files;
-
-                    // list filres with ordering by name, adc
-                    files = this.sffs.getFileList(/* orderByDate=false */);
-                    this.assertEqual("file0.txt", files[0].fname, "getFileList(false) is expected to sort files by name");
-
-                    // list files ordering by date, asc
-                    files = this.sffs.getFileList(true /* orderByDate=true */);
-                    this.assertEqual("file1.txt", files[0].fname, "getFileList(true) is expected to sort files by creation date");
-                    ok();
-
-                } catch (e) {
-                    err(e);
-                }
-            }.bindenv(this));
-        }.bindenv(this));
-    }
-
-    /**
-     * Test .fileExists()
-     */
-    function test04_fileExists() {
-        this.assertEqual(true, this.sffs.fileExists("file1.txt"));
-        this.assertEqual(false, this.sffs.fileExists("nonexisting-file.txt"));
-        this.assertEqual(false, this.sffs.fileExists(""));
-        this.assertEqual(false, this.sffs.fileExists("\0"));
-    }
-
-    /**
-     * Test .fileSize()
-     */
-    function test05_fileSize() {
-        // empty file
-        this.assertEqual(0, this.sffs.fileSize("file1.txt"));
-
-        // nonexistent file
-        this.assertThrowsError(function () {
-            this.sffs.fileSize("nonexisting-file.txt");
-        }, this);
-
-        // create file
-        local f = this.sffs.open("file2.txt", "w");
-        f.write(blob(100))
-        f.close();
-
-        // check existing file size
-        this.assertEqual(100, this.sffs.fileSize("file2.txt"));
-    }
-
-    /**
-     * Test .isFileOpen()
-     */
-    function test06_isFileOpen() {
-        // existing closed file
-        this.assertEqual(false, this.sffs.isFileOpen("file1.txt"));
-
-        // non-existing file
-        this.assertThrowsError(function () {
-            this.sffs.isFileOpen("nonexisting-file.txt");
-        }, this);
-
-        // open file
-        local f = this.sffs.open("file2.txt", "r");
-        this.assertEqual(true, this.sffs.isFileOpen("file2.txt"));
-        f.close();
-    }
-
-    /**
-     * Test .open()
-     */
-    function test07_Open() {
-        local f;
-
-        // existing file for reading
-        f = this.sffs.open("file1.txt", "r");
-        this.assertTrue(f instanceof SPIFlashFileSystem.File);
-        f.close();
-
-        // non-existing file for reading
-        this.assertThrowsError(function () {
-            this.sffs.open("nonexisting-file.txt", "r");
-        }, this);
-
-        // existing file for writing
-        this.assertThrowsError(function () {
-            this.sffs.open("file1.txt", "w");
-        }, this);
-
-        // non-existing file for writing
-        f = this.sffs.open("file3.txt", "w");
-        this.assertTrue(f instanceof SPIFlashFileSystem.File);
-        this.assertTrue(this.sffs.isFileOpen("file3.txt"));
-        f.close();
-    }
-
-    /**
-     * Test .eraseFile()
-     */
-    function test08_EraseFile() {
-        // existing file
-        this.sffs.eraseFile("file1.txt");
-        this.assertEqual(false, this.sffs.fileExists("file1.txt"));
-
-        // non-existing file
-        this.assertThrowsError(function () {
-            this.sffs.eraseFile("nonexisting-file.txt");
-        }, this);
-
-        // existing open file
-        local f = this.sffs.open("file2.txt", "r");
-        this.assertThrowsError(@ () this.sffs.eraseFile("file2.txt"), this);
-        this.assertEqual(true, this.sffs.fileExists("file2.txt"));
-        f.close();
-    }
-
-    /**
-     * Test .eraseFiles()
-     */
-    function test09_EraseFiles() {
-        local files;
-
-        // check that there are files
-        files = this.sffs.getFileList();
-        this.assertGreater(files.len(), 0);
-
-        // erase all files
-        this.sffs.eraseFiles();
-
-        // check that tere are no files
-        files = this.sffs.getFileList();
-        this.assertEqual(0, files.len());
-    }
-
-    /**
-     * Test .dimensions()
-     */
-    function test10_Dimensions() {
-        this.assertDeepEqual(
-            {
-                "start": 0,
-                "size": this.size,
-                "end": this.size,
-                "len": this.size,
-                "pages": this.size / SPIFLASHFILESYSTEM_PAGE_SIZE
-            },
-            this.sffs.dimensions()
-        );
-    }
-
-    /**
-     * Test .created()
-     */
-    function test11_Created() {
-        // test that created date on newly created file == time()
-        this.sffs.open("file4.txt", "w").close();
-        this.assertClose(time(), this.sffs.created("file4.txt"), 1);
-    }
-
-    /**
-     * Erase flash
-     */
-    function tearDown() {
-        this.sffs.eraseAll();
-        this.test01_FileListWhenEmpty();
-        return "Flash erased";
-    }
+  //
+  // an empty filename or nul
+  // max+1 length of filename
+  //
+  function test12_fileOpen() {
+    _openTest(null);
+    _openTest("");
+    // create 256+ filename
+    local filename = "01234567890";
+    while (filename.len() <= 256)
+      filename += filename;
+    // too long filename
+    _openTest(filename);
+  }
 }

--- a/tests/SFFS.device.test.nut
+++ b/tests/SFFS.device.test.nut
@@ -78,13 +78,17 @@ class SFFSTestCase extends BaseSffsTestCase {
 
                     // list filres with ordering by name, adc
                     files = sffs.getFileList( /* orderByDate=false */ );
-                    assertEqual("file0.txt", files[0].fname,
-                                "getFileList(false) is expected to sort files by name");
+                    if ("file0.txt" != files[0].fname) {
+                        err("getFileList(false) is expected to sort files by name");
+                        return;
+                    }
 
                     // list files ordering by date, asc
                     files = sffs.getFileList(true /* orderByDate=true */ );
-                    assertEqual("file1.txt", files[0].fname,
-                                "getFileList(true) is expected to sort files by creation date");
+                    if ("file1.txt" != files[0].fname) {
+                        err("getFileList(true) is expected to sort files by creation date");
+                        return;
+                    }
                     ok();
 
                 } catch (e) {

--- a/tests/SFFS.device.test.nut
+++ b/tests/SFFS.device.test.nut
@@ -28,233 +28,235 @@
 
 class SFFSTestCase extends BaseSffsTestCase {
 
-  //
-  // Test .fileList() with empty FAT
-  //
-  function test01_FileListWhenEmpty() {
-    // chekc that nothing is listed yet
-    local files = this.sffs.getFileList();
-    this.assertTrue(type(files) == "array");
-    this.assertEqual(0, files.len());
-  }
-
-  //
-  //Test .fileList() after cteating a file
-  //
-  function test02_FileListNonEmpty() {
-    // create an empty file
-    createFile("file1.txt");
-
-    // check that it's listed
-    local files = this.sffs.getFileList();
-    this.assertTrue(type(files) == "array");
-    this.assertEqual(1, files.len());
-
-    // check creation date
-    this.assertClose(time(), files[0].created, 1);
-
-    // check the rest of the files data structure
-    files[0]["created"] <- 0;
-    this.assertDeepEqual([{
-      "size": 0,
-      "id": 1,
-      "created": 0,
-      "fname": "file1.txt"
-    }], files);
-  }
-
-  //
-  //Test ordering of files in .fileList()
-  //
-  function test03_FileListOrdering() {
-    return Promise(function(ok, err) {
-      imp.wakeup(2, function() {
-        try {
-          // creat file a with later date, but alphabetically
-          // preceedeing already existing file1.txt
-          this.sffs.open("file0.txt", "w").close();
-
-          local files;
-
-          // list filres with ordering by name, adc
-          files = this.sffs.getFileList( /* orderByDate=false */ );
-          this.assertEqual("file0.txt", files[0].fname, "getFileList(false) is expected to sort files by name");
-
-          // list files ordering by date, asc
-          files = this.sffs.getFileList(true /* orderByDate=true */ );
-          this.assertEqual("file1.txt", files[0].fname, "getFileList(true) is expected to sort files by creation date");
-          ok();
-
-        } catch (e) {
-          err(e);
-        }
-      }.bindenv(this));
-    }.bindenv(this));
-  }
-
-  //
-  //Test .fileExists()
-  //
-  function test04_fileExists() {
-    this.assertEqual(true, this.sffs.fileExists("file1.txt"));
-    this.assertEqual(false, this.sffs.fileExists("nonexisting-file.txt"));
-    this.assertEqual(false, this.sffs.fileExists(""));
-    this.assertEqual(false, this.sffs.fileExists("\0"));
-  }
-
-  //
-  //Test .fileSize()
-  //
-  function test05_fileSize() {
-    // empty file
-    this.assertEqual(0, this.sffs.fileSize("file1.txt"));
-
-    // nonexistent file
-    this.assertThrowsError(function() {
-      this.sffs.fileSize("nonexisting-file.txt");
-    }, this);
-
-    // create file
-    local f = this.sffs.open("file2.txt", "w");
-    f.write(blob(100))
-    f.close();
-
-    // check existing file size
-    this.assertEqual(100, this.sffs.fileSize("file2.txt"));
-  }
-
-  //
-  //Test .isFileOpen()
-  //
-  function test06_isFileOpen() {
-    // existing closed file
-    this.assertEqual(false, this.sffs.isFileOpen("file1.txt"));
-
-    // non-existing file
-    this.assertThrowsError(function() {
-      this.sffs.isFileOpen("nonexisting-file.txt");
-    }, this);
-
-    // open file
-    local f = this.sffs.open("file2.txt", "r");
-    this.assertEqual(true, this.sffs.isFileOpen("file2.txt"));
-    f.close();
-  }
-
-  //
-  //Test .open()
-  //
-  function test07_Open() {
-    local f;
-
-    // existing file for reading
-    f = this.sffs.open("file1.txt", "r");
-    this.assertTrue(f instanceof SPIFlashFileSystem.File);
-    f.close();
-
-    // non-existing file for reading
-    this.assertThrowsError(function() {
-      this.sffs.open("nonexisting-file.txt", "r");
-    }, this);
-
-    // existing file for writing
-    this.assertThrowsError(function() {
-      this.sffs.open("file1.txt", "w");
-    }, this);
-
-    // non-existing file for writing
-    f = this.sffs.open("file3.txt", "w");
-    this.assertTrue(f instanceof SPIFlashFileSystem.File);
-    this.assertTrue(this.sffs.isFileOpen("file3.txt"));
-    f.close();
-  }
-
-  //
-  //Test .eraseFile()
-  //
-  function test08_EraseFile() {
-    // existing file
-    this.sffs.eraseFile("file1.txt");
-    this.assertEqual(false, this.sffs.fileExists("file1.txt"));
-
-    // non-existing file
-    this.assertThrowsError(function() {
-      this.sffs.eraseFile("nonexisting-file.txt");
-    }, this);
-
-    // existing open file
-    local f = this.sffs.open("file2.txt", "r");
-    this.assertThrowsError(@() this.sffs.eraseFile("file2.txt"), this);
-    this.assertEqual(true, this.sffs.fileExists("file2.txt"));
-    f.close();
-  }
-
-  //
-  //Test .eraseFiles()
-  //
-  function test09_EraseFiles() {
-    local files;
-
-    // check that there are files
-    files = this.sffs.getFileList();
-    this.assertGreater(files.len(), 0);
-
-    // erase all files
-    this.sffs.eraseFiles();
-
-    // check that tere are no files
-    files = this.sffs.getFileList();
-    this.assertEqual(0, files.len());
-  }
-
-  //
-  //Test .dimensions()
-  //
-  function test10_Dimensions() {
-    this.assertDeepEqual({
-        "start": 0,
-        "size": this.size,
-        "end": this.size,
-        "len": this.size,
-        "pages": this.size / SPIFLASHFILESYSTEM_PAGE_SIZE
-      },
-      this.sffs.dimensions()
-    );
-  }
-
-  //
-  //Test .created()
-  //
-  function test11_Created() {
-    // test that created date on newly created file == time()
-    this.sffs.open("file4.txt", "w").close();
-    this.assertClose(time(), this.sffs.created("file4.txt"), 1);
-  }
-
-  //
-  // Helper method to test filename input parameters
-  //
-  function _openTest(filename) {
-    try {
-      sffs.open(null, "w");
-      assertTrue(false, "An ERR_INVALID_FILE ex")
-    } catch (e) {
-      assertEqual("Invalid filename", e);
+    //
+    // Test .fileList() with empty FAT
+    //
+    function test01_FileListWhenEmpty() {
+        // chekc that nothing is listed yet
+        local files = sffs.getFileList();
+        assertTrue(type(files) == "array");
+        assertEqual(0, files.len());
     }
-  }
 
-  //
-  // an empty filename or nul
-  // max+1 length of filename
-  //
-  function test12_fileOpen() {
-    _openTest(null);
-    _openTest("");
-    // create 256+ filename
-    local filename = "01234567890";
-    while (filename.len() <= 256)
-      filename += filename;
-    // too long filename
-    _openTest(filename);
-  }
+    //
+    //Test .fileList() after cteating a file
+    //
+    function test02_FileListNonEmpty() {
+        // create an empty file
+        createFile("file1.txt");
+
+        // check that it's listed
+        local files = sffs.getFileList();
+        assertTrue(type(files) == "array");
+        assertEqual(1, files.len());
+
+        // check creation date
+        assertClose(time(), files[0].created, 1);
+
+        // check the rest of the files data structure
+        files[0]["created"] <- 0;
+        assertDeepEqual([{
+            "size": 0,
+            "id": 1,
+            "created": 0,
+            "fname": "file1.txt"
+        }], files);
+    }
+
+    //
+    //Test ordering of files in .fileList()
+    //
+    function test03_FileListOrdering() {
+        return Promise(function(ok, err) {
+            imp.wakeup(2, function() {
+                try {
+                    // creat file a with later date, but alphabetically
+                    // preceedeing already existing file1.txt
+                    sffs.open("file0.txt", "w").close();
+
+                    local files;
+
+                    // list filres with ordering by name, adc
+                    files = sffs.getFileList( /* orderByDate=false */ );
+                    assertEqual("file0.txt", files[0].fname,
+                                "getFileList(false) is expected to sort files by name");
+
+                    // list files ordering by date, asc
+                    files = sffs.getFileList(true /* orderByDate=true */ );
+                    assertEqual("file1.txt", files[0].fname,
+                                "getFileList(true) is expected to sort files by creation date");
+                    ok();
+
+                } catch (e) {
+                    err(e);
+                }
+            }.bindenv(this));
+        }.bindenv(this));
+    }
+
+    //
+    //Test .fileExists()
+    //
+    function test04_fileExists() {
+        assertEqual(true, sffs.fileExists("file1.txt"));
+        assertEqual(false, sffs.fileExists("nonexisting-file.txt"));
+        assertEqual(false, sffs.fileExists(""));
+        assertEqual(false, sffs.fileExists("\0"));
+    }
+
+    //
+    //Test .fileSize()
+    //
+    function test05_fileSize() {
+        // empty file
+        assertEqual(0, sffs.fileSize("file1.txt"));
+
+        // nonexistent file
+        assertThrowsError(function() {
+            sffs.fileSize("nonexisting-file.txt");
+        }, this);
+
+        // create file
+        local f = sffs.open("file2.txt", "w");
+        f.write(blob(1    ))
+        f.close();
+
+        // check existing file size
+        assertEqual(1    , sffs.fileSize("file2.txt"));
+    }
+
+    //
+    //Test .isFileOpen()
+    //
+    function test06_isFileOpen() {
+        // existing closed file
+        assertEqual(false, sffs.isFileOpen("file1.txt"));
+
+        // non-existing file
+        assertThrowsError(function() {
+            sffs.isFileOpen("nonexisting-file.txt");
+        }, this);
+
+        // open file
+        local f = sffs.open("file2.txt", "r");
+        assertEqual(true, sffs.isFileOpen("file2.txt"));
+        f.close();
+    }
+
+    //
+    //Test .open()
+    //
+    function test07_Open() {
+        local f;
+
+        // existing file for reading
+        f = sffs.open("file1.txt", "r");
+        assertTrue(f instanceof SPIFlashFileSystem.File);
+        f.close();
+
+        // non-existing file for reading
+        assertThrowsError(function() {
+            sffs.open("nonexisting-file.txt", "r");
+        }, this);
+
+        // existing file for writing
+        assertThrowsError(function() {
+            sffs.open("file1.txt", "w");
+        }, this);
+
+        // non-existing file for writing
+        f = sffs.open("file3.txt", "w");
+        assertTrue(f instanceof SPIFlashFileSystem.File);
+        assertTrue(sffs.isFileOpen("file3.txt"));
+        f.close();
+    }
+
+    //
+    //Test .eraseFile()
+    //
+    function test08_EraseFile() {
+        // existing file
+        sffs.eraseFile("file1.txt");
+        assertEqual(false, sffs.fileExists("file1.txt"));
+
+        // non-existing file
+        assertThrowsError(function() {
+            sffs.eraseFile("nonexisting-file.txt");
+        }, this);
+
+        // existing open file
+        local f = sffs.open("file2.txt", "r");
+        assertThrowsError(@() sffs.eraseFile("file2.txt"), this);
+        assertEqual(true, sffs.fileExists("file2.txt"));
+        f.close();
+    }
+
+    //
+    //Test .eraseFiles()
+    //
+    function test09_EraseFiles() {
+        local files;
+
+        // check that there are files
+        files = sffs.getFileList();
+        assertGreater(files.len(), 0);
+
+        // erase all files
+        sffs.eraseFiles();
+
+        // check that tere are no files
+        files = sffs.getFileList();
+        assertEqual(0, files.len());
+    }
+
+    //
+    //Test .dimensions()
+    //
+    function test10_Dimensions() {
+        assertDeepEqual({
+                "start": 0,
+                "size": size,
+                "end": size,
+                "len": size,
+                "pages": size / SPIFLASHFILESYSTEM_PAGE_SIZE
+            },
+            sffs.dimensions()
+        );
+    }
+
+    //
+    //Test .created()
+    //
+    function test11_Created() {
+        // test that created date on newly created file == time()
+        sffs.open("file4.txt", "w").close();
+        assertClose(time(), sffs.created("file4.txt"), 1);
+    }
+
+    //
+    // Helper method to test filename input parameters
+    //
+    function _openTest(filename) {
+        try {
+            sffs.open(filename, "w");
+            assertTrue(false, "An ERR_INVALID_FILE ex")
+        } catch (e) {
+            assertEqual("Invalid filename", e);
+        }
+    }
+
+    //
+    // an empty filename or nul
+    // max+1 length of filename
+    //
+    function test12_fileOpen() {
+        _openTest(null);
+        _openTest("");
+        // create 256+ filename
+        local filename = "01234567890";
+        while (filename.len() <= 256)
+            filename += filename;
+        // too long filename
+        _openTest(filename);
+    }
 }

--- a/tests/SffsEraseVerification.device.test.nut
+++ b/tests/SffsEraseVerification.device.test.nut
@@ -27,99 +27,99 @@
 @include __PATH__ + "/BaseSFFS.device.nut"
 
 class SFFSTestCase extends BaseSffsTestCase {
-  size = 0;
-  sffs = null;
+    size = 0;
+    sffs = null;
 
-  // Test that all pages are free after eraseAll
-  function test01_eraseAll() {
-    for (local i = 0; i < this.pages; ++i) {
-      hardware.spiflash.enable();
-      local buffer = hardware.spiflash.read(this.start + i * 4096, 4096);
-      hardware.spiflash.disable();
+    // Test that all pages are free after eraseAll
+    function test01_eraseAll() {
+        for (local i = 0; i < this.pages; ++i) {
+            hardware.spiflash.enable();
+            local buffer = hardware.spiflash.read(this.start + i * 4096, 4096);
+            hardware.spiflash.disable();
 
-      local success = true;
-      foreach(b in buffer) {
-        success = success && (b == 0xFF);
-      }
+            local success = true;
+            foreach(b in buffer) {
+                success = success && (b == 0xFF);
+            }
 
-      this.assertTrue(success);
+            this.assertTrue(success);
+        }
     }
-  }
 
-  // init function create FAT table in memory
-  // not of flash, therefore all headers of pages should
-  // be free after function call
-  function test02_init() {
-    return Promise(function(ok, err) {
-      this.sffs.init(function(v) {
-        // all pages should be empty
-        local success = true;
-        for (local i = 0; i < this.pages; ++i) {
-          hardware.spiflash.enable();
-          local header = hardware.spiflash.read(this.start + i * 4096, 4096);
-          hardware.spiflash.disable();
-          // Check File ID, span ID and size
-          for (local i = 0; i < 3; ++i) {
-            local w = header.readn('w');
-            success = success && (w == 0xFFFF);
-          }
+    // init function create FAT table in memory
+    // not of flash, therefore all headers of pages should
+    // be free after function call
+    function test02_init() {
+        return Promise(function(ok, err) {
+            this.sffs.init(function(v) {
+                // all pages should be empty
+                local success = true;
+                for (local i = 0; i < this.pages; ++i) {
+                    hardware.spiflash.enable();
+                    local header = hardware.spiflash.read(this.start + i * 4096, 4096);
+                    hardware.spiflash.disable();
+                    // Check File ID, span ID and size
+                    for (local i = 0; i < 3; ++i) {
+                        local w = header.readn('w');
+                        success = success && (w == 0xFFFF);
+                    }
 
-          if (!success)
-            break;
-        }
-        success ? ok() : err("All pages should be empty after erase and init");
-      }.bindenv(this));
-    }.bindenv(this));
-  }
+                    if (!success)
+                        break;
+                }
+                success ? ok() : err("All pages should be empty after erase and init");
+            }.bindenv(this));
+        }.bindenv(this));
+    }
 
-  function test03_init() {
-    // create threee single page files
-    createFile("tet1.txt", "payload");
-    createFile("tet2.txt", "payload");
-    createFile("tet3.txt", "payload");
-    // check that only three pages are marked as not free
-    // after init
-    return Promise(function(ok, err) {
-      this.sffs.init(function(v) {
-        if (3 != v.len()) {
-          err("Wrong number of files on init. 3 is expected got " + v.len());
-          return;
-        }
-        // start calculate marked pages
-        local stats = {
-          "free": 0,
-          "used": 0
-        };
-        // all pages should be empty
-        for (local i = 0; i < this.pages; ++i) {
-          hardware.spiflash.enable();
-          local header = hardware.spiflash.read(this.start + i * 4096, 4096);
-          hardware.spiflash.disable();
-          // Check first file id only
-          (header.readn('w') == 0xFFFF ? stats.free++ : stats.used++);
-        }
-        if (stats.free == this.pages - 3 && stats.used == 3)
-          ok();
-        else
-          err("Expected 3 used pages got " + stats.used);
-      }.bindenv(this));
-    }.bindenv(this));
-  }
+    function test03_init() {
+        // create threee single page files
+        createFile("tet1.txt", "payload");
+        createFile("tet2.txt", "payload");
+        createFile("tet3.txt", "payload");
+        // check that only three pages are marked as not free
+        // after init
+        return Promise(function(ok, err) {
+            this.sffs.init(function(v) {
+                if (3 != v.len()) {
+                    err("Wrong number of files on init. 3 is expected got " + v.len());
+                    return;
+                }
+                // start calculate marked pages
+                local stats = {
+                    "free": 0,
+                    "used": 0
+                };
+                // all pages should be empty
+                for (local i = 0; i < this.pages; ++i) {
+                    hardware.spiflash.enable();
+                    local header = hardware.spiflash.read(this.start + i * 4096, 4096);
+                    hardware.spiflash.disable();
+                    // Check first file id only
+                    (header.readn('w') == 0xFFFF ? stats.free++ : stats.used++);
+                }
+                if (stats.free == this.pages - 3 && stats.used == 3)
+                    ok();
+                else
+                    err("Expected 3 used pages got " + stats.used);
+            }.bindenv(this));
+        }.bindenv(this));
+    }
 
-  // Check bad pages on init
-  // Expected 3 used pages for 3 files
-  // and 2 bad pages should not be detected as files
-  function test04_init() {
-    // Create 2 bad pages
-    makeBadPage();
-    makeBadPage();
-    return Promise(function(ok, err) {
-      this.sffs.init(function(v) {
-        if (3 == v.len())
-          ok();
-        else
-          err("Wrong number of files on init. 3 is expected got " + v.len());
-      }.bindenv(this));
-    }.bindenv(this));
-  }
+    // Check bad pages on init
+    // Expected 3 used pages for 3 files
+    // and 2 bad pages should not be detected as files
+    function test04_init() {
+        // Create 2 bad pages
+        makeBadPage();
+        makeBadPage();
+        return Promise(function(ok, err) {
+            this.sffs.init(function(v) {
+                if (3 == v.len())
+                    ok();
+                else
+                    err("Wrong number of files on init. 3 is expected got " + v.len());
+            }.bindenv(this));
+        }.bindenv(this));
+    }
 }

--- a/tests/SffsEraseVerification.device.test.nut
+++ b/tests/SffsEraseVerification.device.test.nut
@@ -1,0 +1,125 @@
+// MIT License
+//
+// Copyright 2017 Electric Imp
+//
+// SPDX-License-Identifier: MIT
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO
+// EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES
+// OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+// ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+// "Promise" symbol is injected dependency from ImpUnit_Promise module,
+// while class being tested can be accessed from global scope as "::Promise".
+
+@include __PATH__ + "/BaseSFFS.device.nut"
+
+class SFFSTestCase extends BaseSffsTestCase {
+  size = 0;
+  sffs = null;
+
+  // Test that all pages are free after eraseAll
+  function test01_eraseAll() {
+    for (local i = 0; i < this.pages; ++i) {
+      hardware.spiflash.enable();
+      local buffer = hardware.spiflash.read(this.start + i * 4096, 4096);
+      hardware.spiflash.disable();
+
+      local success = true;
+      foreach(b in buffer) {
+        success = success && (b == 0xFF);
+      }
+
+      this.assertTrue(success);
+    }
+  }
+
+  // init function create FAT table in memory
+  // not of flash, therefore all headers of pages should
+  // be free after function call
+  function test02_init() {
+    return Promise(function(ok, err) {
+      this.sffs.init(function(v) {
+        // all pages should be empty
+        local success = true;
+        for (local i = 0; i < this.pages; ++i) {
+          hardware.spiflash.enable();
+          local header = hardware.spiflash.read(this.start + i * 4096, 4096);
+          hardware.spiflash.disable();
+          // Check File ID, span ID and size
+          for (local i = 0; i < 3; ++i) {
+            local w = header.readn('w');
+            success = success && (w == 0xFFFF);
+          }
+
+          if (!success)
+            break;
+        }
+        success ? ok() : err("All pages should be empty after erase and init");
+      }.bindenv(this));
+    }.bindenv(this));
+  }
+
+  function test03_init() {
+    // create threee single page files
+    createFile("tet1.txt", "payload");
+    createFile("tet2.txt", "payload");
+    createFile("tet3.txt", "payload");
+    // check that only three pages are marked as not free
+    // after init
+    return Promise(function(ok, err) {
+      this.sffs.init(function(v) {
+        if (3 != v.len()) {
+          err("Wrong number of files on init. 3 is expected got " + v.len());
+          return;
+        }
+        // start calculate marked pages
+        local stats = {
+          "free": 0,
+          "used": 0
+        };
+        // all pages should be empty
+        for (local i = 0; i < this.pages; ++i) {
+          hardware.spiflash.enable();
+          local header = hardware.spiflash.read(this.start + i * 4096, 4096);
+          hardware.spiflash.disable();
+          // Check first file id only
+          (header.readn('w') == 0xFFFF ? stats.free++ : stats.used++);
+        }
+        if (stats.free == this.pages - 3 && stats.used == 3)
+          ok();
+        else
+          err("Expected 3 used pages got " + stats.used);
+      }.bindenv(this));
+    }.bindenv(this));
+  }
+
+  // Check bad pages on init
+  // Expected 3 used pages for 3 files
+  // and 2 bad pages should not be detected as files
+  function test04_init() {
+    // Create 2 bad pages
+    makeBadPage();
+    makeBadPage();
+    return Promise(function(ok, err) {
+      this.sffs.init(function(v) {
+        if (3 == v.len())
+          ok();
+        else
+          err("Wrong number of files on init. 3 is expected got " + v.len());
+      }.bindenv(this));
+    }.bindenv(this));
+  }
+}

--- a/tests/SffsFatInternalApi.device.test.nut
+++ b/tests/SffsFatInternalApi.device.test.nut
@@ -27,308 +27,308 @@
 @include __PATH__ + "/BaseSFFS.device.nut"
 
 class SffsFatInternalApi extends BaseSffsTestCase {
-  _stats = null;
-  // extra parameters for test purpose
-  function setUpParameters() {
-    _stats = {
-      "bad": 0,
-      "used": 0,
-      "free": this.pages,
-      "erased": 0
-    };
-  }
+    _stats = null;
+    // extra parameters for test purpose
+    function setUpParameters() {
+        _stats = {
+            "bad": 0,
+            "used": 0,
+            "free": pages,
+            "erased": 0
+        };
+    }
 
-  //
-  // Check constructor on a newly created FS
-  //
-  function test01_constructor() {
-    // create a new FAT
-    local fat = SPIFlashFileSystem.FAT(this.sffs, this.pages);
+    //
+    // Check constructor on a newly created FS
+    //
+    function test01_constructor() {
+        // create a new FAT
+        local fat = SPIFlashFileSystem.FAT(sffs, pages);
 
-    // Check that all blocks are free
-    this.assertDeepEqual(fat.getStats(), _stats);
+        // Check that all blocks are free
+        assertDeepEqual(fat.getStats(), _stats);
 
-    fat = SPIFlashFileSystem.FAT(this.sffs);
+        fat = SPIFlashFileSystem.FAT(sffs);
+        // FAT constructor without pages parameter
+        // should preform SCAN of the FS
+        assertDeepEqual(fat.getStats(), _stats);
+    }
+
+    //
+    // Constructor doesn't perform SCAN
+    // if the "pages" argument provided
+    //
+    function test02_constructor() {
+        createFile("test1.txt", "NOT EMPTY PAYLOAD");
+        // Create a new FAT over an existing FS
+        local fat = SPIFlashFileSystem.FAT(sffs, pages);
+
+        // Assume that all blocks are free
+        // because of second parameter provided to the constructor
+        assertDeepEqual(fat.getStats(), _stats);
+    }
+
     // FAT constructor without pages parameter
     // should preform SCAN of the FS
-    this.assertDeepEqual(fat.getStats(), _stats);
-  }
+    function test03_constructor() {
+        _stats.free -= 1;
+        _stats.used += 1;
 
-  //
-  // Constructor doesn't perform SCAN
-  // if the "pages" argument provided
-  //
-  function test02_constructor() {
-    createFile("test1.txt", "NOT EMPTY PAYLOAD");
-    // Create a new FAT over an existing FS
-    local fat = SPIFlashFileSystem.FAT(this.sffs, this.pages);
+        local fat = SPIFlashFileSystem.FAT(sffs);
+        assertDeepEqual(fat.getStats(), _stats);
+    }
 
-    // Assume that all blocks are free
-    // because of second parameter provided to the constructor
-    this.assertDeepEqual(fat.getStats(), _stats);
-  }
+    //
+    // Check that constructor does not recover
+    // deleted files
+    // Note: sffs.fat object
+    function test04_constructor() {
+        sffs.eraseFile("test1.txt");
+        _stats.used -= 1;
+        _stats.erased += 1;
 
-  // FAT constructor without pages parameter
-  // should preform SCAN of the FS
-  function test03_constructor() {
-    _stats.free -= 1;
-    _stats.used += 1;
+        local fat = SPIFlashFileSystem.FAT(sffs);
+        assertDeepEqual(fat.getStats(), _stats);
+    }
 
-    local fat = SPIFlashFileSystem.FAT(this.sffs);
-    this.assertDeepEqual(fat.getStats(), _stats);
-  }
+    function test05_scan() {
+        createFile("test1.txt", "NOT EMPTY PAYLOAD");
+        createFile("test2.txt", "NOT EMPTY PAYLOAD");
 
-  //
-  // Check that constructor does not recover
-  // deleted files
-  // Note: sffs.fat object
-  function test04_constructor() {
-    sffs.eraseFile("test1.txt");
-    _stats.used -= 1;
-    _stats.erased += 1;
+        sffs._fat.scan();
+        _stats.used += 2;
+        _stats.free -= 2;
+        // Total:
+        // 2 used pages
+        // 1 erased page
+        assertDeepEqual(sffs._fat.getStats(), _stats);
+    }
 
-    local fat = SPIFlashFileSystem.FAT(sffs);
-    this.assertDeepEqual(fat.getStats(), _stats);
-  }
+    function test06_scanBadPage() {
+        // this mehod creates BAD pages on flash
+        makeBadPage();
 
-  function test05_scan() {
-    createFile("test1.txt", "NOT EMPTY PAYLOAD");
-    createFile("test2.txt", "NOT EMPTY PAYLOAD");
+        _stats.bad += 1; // only one page was damaged
+        _stats.free -= 1;
+        sffs._fat.scan();
+        assertDeepEqual(_stats, sffs._fat.getStats());
+    }
 
-    sffs._fat.scan();
-    _stats.used += 2;
-    _stats.free -= 2;
-    // Total:
-    // 2 used pages
-    // 1 erased page
-    this.assertDeepEqual(sffs._fat.getStats(), _stats);
-  }
+    function test07_get() {
+        local file = sffs._fat.get("test2.txt");
+        // it should be the same file
+        assertDeepEqual(file, sffs._fat.get(file.id));
+    }
 
-  function test06_scanBadPage() {
-    // this mehod creates BAD pages on flash
-    makeBadPage();
+    //
+    // Test that get throw ERR_FILE_NOT_FOUND exception
+    //
+    function test08_get_throw() {
+        return Promise(function(ok, err) {
+            imp.wakeup(2, function() {
+                try {
+                    local f = sffs._fat.get("file0.txt");
+                    err("Expected file not found exception.");
+                } catch (e) {
+                    ok();
+                }
+            }.bindenv(this));
+        }.bindenv(this));
+    }
 
-    _stats.bad += 1; // only one page was damaged
-    _stats.free -= 1;
-    sffs._fat.scan();
-    this.assertDeepEqual(_stats, sffs._fat.getStats());
-  }
+    //
+    // Note: FAT.getFileList method covered by SFFS.getFileList
+    //
 
-  function test07_get() {
-    local file = sffs._fat.get("test2.txt");
-    // it should be the same file
-    this.assertDeepEqual(file, sffs._fat.get(file.id));
-  }
+    //
+    // Search file ID by name:
+    // 1. successful search
+    // 2. throw ERR_FILE_NOT_FOUND
+    function test09_getFileId() {
+        local id = sffs._fat.getFileId("test1.txt")
+        assertEqual(true, id >= 0);
 
-  //
-  // Test that get throw ERR_FILE_NOT_FOUND exception
-  //
-  function test08_get_throw() {
-    return Promise(function(ok, err) {
-      imp.wakeup(2, function() {
-        try {
-          local f = this.sffs._fat.get("file0.txt");
-          err("Expected file not found exception.");
-        } catch (e) {
-          ok();
-        }
-      }.bindenv(this));
-    }.bindenv(this));
-  }
+        return Promise(function(ok, err) {
+            imp.wakeup(2, function() {
+                try {
+                    local id = sffs._fat.get("file0.txt");
+                    err("Expected file not found exception.");
+                } catch (e) {
+                    ok();
+                }
+            }.bindenv(this));
+        }.bindenv(this));
+    }
 
-  //
-  // Note: FAT.getFileList method covered by SFFS.getFileList
-  //
+    //
+    // Note: FAT.fileExists method covered by SFFS.fileExists tests
+    //
 
-  //
-  // Search file ID by name:
-  // 1. successful search
-  // 2. throw ERR_FILE_NOT_FOUND
-  function test09_getFileId() {
-    local id = sffs._fat.getFileId("test1.txt")
-    this.assertEqual(true, id >= 0);
+    // Note: get free page is based on random page selection
+    //             algorithm, therefore it could return a different
+    //             values on each call.
+    //             There is no page holding/reservation via this
+    //             method.
+    //
+    function test10_getFreePage() {
+        local dim = sffs.dimensions();
+        local page = sffs._fat.getFreePage();
+        // test that page in an available flash memory range
+        assertEqual(true, page >= dim.start && page < dim.end);
 
-    return Promise(function(ok, err) {
-      imp.wakeup(2, function() {
-        try {
-          local id = this.sffs._fat.get("file0.txt");
-          err("Expected file not found exception.");
-        } catch (e) {
-          ok();
-        }
-      }.bindenv(this));
-    }.bindenv(this));
-  }
+        // Mark all pages as used to get ERR_NO_FREE_SPACE exception
+        return Promise(function(ok, err) {
+            imp.wakeup(2, function() {
+                try {
+                    local page = sffs._fat.getFreePage();
+                    while (page >= 0) {
+                        sffs._fat.markPage(page, SPIFLASHFILESYSTEM_STATUS_USED);
+                        page = sffs._fat.getFreePage();
+                    }
+                    err("Expected no free space exception.");
+                } catch (e) {
+                    ok();
+                }
+            }.bindenv(this));
+        }.bindenv(this));
+    }
 
-  //
-  // Note: FAT.fileExists method covered by SFFS.fileExists tests
-  //
+    //
+    // Check that there is no problems to make a transition
+    // from each pages state to another one
+    // Note: current implementaion of the markPage doesn't have
+    //             state tracker for the transition from BAD->free
+    //             FREE->ERASED etc...
+    //             The purpose of this test is to catch if such
+    //             functionality will appear in the future
+    //
+    function test11_markPage() {
+        sffs.eraseAll();
+        local addr = sffs._fat.getFreePage();
+        return Promise(function(ok, err) {
+            imp.wakeup(2, function() {
+                try {
+                    local flags = [SPIFLASHFILESYSTEM_STATUS_FREE,
+                        SPIFLASHFILESYSTEM_STATUS_ERASED,
+                        SPIFLASHFILESYSTEM_STATUS_USED,
+                        SPIFLASHFILESYSTEM_STATUS_BAD
+                    ];
+                    for (local i = 0; i < flags.len(); ++i) {
+                        for (local j = 0; j < flags.len(); ++j) {
+                            sffs._fat.markPage(addr, flags[i]);
+                            sffs._fat.markPage(addr, flags[j]);
+                        }
+                    }
+                    ok();
+                } catch (e) {
+                    err(e, "No exceptions expected. Please add testcase for markPage.");
+                }
+            }.bindenv(this));
+        }.bindenv(this));
+    }
 
-  // Note: get free page is based on random page selection
-  //       algorithm, therefore it could return a different
-  //       values on each call.
-  //       There is no page holding/reservation via this
-  //       method.
-  //
-  function test10_getFreePage() {
-    local dim = sffs.dimensions();
-    local page = sffs._fat.getFreePage();
-    // test that page in an available flash memory range
-    this.assertEqual(true, page >= dim.start && page < dim.end);
+    //
+    // Create a very long file
+    // which consists of multiple pages
+    // but do not write a real data
+    //
+    function test12_addPage() {
+        // make an empty FS
+        sffs.eraseAll();
+        // reset an expected stats value
+        _stats = {
+            "bad": 0,
+            "used": 0,
+            "free": pages,
+            "erased": 0
+        };
+        // open file for writing
+        local filename = "test3.txt";
+        local file = sffs.open(filename, "w");
 
-    // Mark all pages as used to get ERR_NO_FREE_SPACE exception
-    return Promise(function(ok, err) {
-      imp.wakeup(2, function() {
-        try {
-          local page = sffs._fat.getFreePage();
-          while (page >= 0) {
+        // Create file for all 64Kb
+        for (local i = 1; i <= pages; ++i) {
+            local page = sffs._fat.getFreePage();
+            sffs._fat.addPage(filename, page);
+            // addPage doesn't mark page ad used
+            // therefore we can get the same free page again and again
+            // to prevent it let's mark it as used
             sffs._fat.markPage(page, SPIFLASHFILESYSTEM_STATUS_USED);
-            page = sffs._fat.getFreePage();
-          }
-          err("Expected no free space exception.");
-        } catch (e) {
-          ok();
+            assertEqual(sffs._fat.getPageCount(filename), i);
+            sffs._fat.addSizeToLastSpan(filename, 123);
         }
-      }.bindenv(this));
-    }.bindenv(this));
-  }
+        // close and remove file
+        file.close();
+        _stats = {
+            "bad": 0,
+            "used": pages,
+            "free": 0,
+            "erased": 0
+        };
+        // All blocks are used
+        assertDeepEqual(sffs._fat.getStats(), _stats);
 
-  //
-  // Check that there is no problems to make a transition
-  // from each pages state to another one
-  // Note: current implementaion of the markPage doesn't have
-  //       state tracker for the transition from BAD->free
-  //       FREE->ERASED etc...
-  //       The purpose of this test is to catch if such
-  //       functionality will appear in the future
-  //
-  function test11_markPage() {
-    sffs.eraseAll();
-    local addr = sffs._fat.getFreePage();
-    return Promise(function(ok, err) {
-      imp.wakeup(2, function() {
-        try {
-          local flags = [SPIFLASHFILESYSTEM_STATUS_FREE,
-            SPIFLASHFILESYSTEM_STATUS_ERASED,
-            SPIFLASHFILESYSTEM_STATUS_USED,
-            SPIFLASHFILESYSTEM_STATUS_BAD
-          ];
-          for (local i = 0; i < 4; ++i) {
-            for (local j = 0; j < 4; ++j) {
-              sffs._fat.markPage(addr, flags[i]);
-              sffs._fat.markPage(addr, flags[j]);
-            }
-          }
-          ok();
-        } catch (e) {
-          err(e, "No exceptions expected. Please add testcase for markPage.");
+        sffs.eraseAll();
+    }
+
+    //
+    // Note: page order was implemented via 2-3 extra copy operations
+    //             but it is not so critical for a performance because sorting
+    //                should happen in scope of one file
+    //
+    function test13_pageOrderBySpan() {
+        // create one 64kb file
+        local file = sffs.open("test1.txt", "w");
+        local buffer = "0123456789012345678901234567890123456789";
+        for (local i = 0; i < (size / buffer.len() - 5); ++i)
+            file.write(buffer);
+
+        local ps = sffs._fat.get("test1.txt").pages;
+
+        file.close();
+
+        // double check that file has correct size
+        assertEqual(pages, ps.len() / 2);
+
+        local testPages = [];
+        // Check foreach page implementation
+        sffs._fat.forEachPage("test1.txt", function(p) {
+            testPages.push(p);
+        });
+
+        local cachedFileId = 0;
+        local cachedSpanId = 0;
+        // Check that all pages are sorted correctly
+        foreach (p in testPages) {
+            // read header of the page
+            hardware.spiflash.enable();
+            local buffer = hardware.spiflash.read(p, 4);
+            hardware.spiflash.disable();
+
+            local fileId = buffer.readn('w');
+            local spanId = buffer.readn('w');
+            // Check that file id is the same for all pages
+            assertTrue(cachedFileId == 0 || cachedFileId == fileId);
+            cachedFileId = fileId;
+            // check that span id is increasing
+            assertEqual(true, spanId >= cachedSpanId);
+            cachedSpanId = spanId;
         }
-      }.bindenv(this));
-    }.bindenv(this));
-  }
-
-  //
-  // Create a very long file
-  // which consists of multiple pages
-  // but do not write a real data
-  //
-  function test12_addPage() {
-    // make an empty FS
-    sffs.eraseAll();
-    // reset an expected stats value
-    _stats = {
-      "bad": 0,
-      "used": 0,
-      "free": this.pages,
-      "erased": 0
-    };
-    // open file for writing
-    local filename = "test3.txt";
-    local file = sffs.open(filename, "w");
-
-    // Create file for all 64Kb
-    for (local i = 1; i <= pages; ++i) {
-      local page = sffs._fat.getFreePage();
-      sffs._fat.addPage(filename, page);
-      // addPage doesn't mark page ad used
-      // therefore we can get the same free page again and again
-      // to prevent it let's mark it as used
-      sffs._fat.markPage(page, SPIFLASHFILESYSTEM_STATUS_USED);
-      assertEqual(sffs._fat.getPageCount(filename), i);
-      sffs._fat.addSizeToLastSpan(filename, 123);
     }
-    // close and remove file
-    file.close();
-    _stats = {
-      "bad": 0,
-      "used": this.pages,
-      "free": 0,
-      "erased": 0
-    };
-    // All blocks are used
-    this.assertDeepEqual(sffs._fat.getStats(), _stats);
 
-    sffs.eraseAll();
-  }
+    //
+    // Helper debug method for debuggin current tests
+    //
+    function debugPrintFSDetails() {
+        sffs._enable();
 
-  //
-  // Note: page order was implemented via 2-3 extra copy operations
-  //       but it is not so critical for a performance because sorting
-  //        should happen in scope of one file
-  //
-  function test13_pageOrderBySpan() {
-    // create one 64kb file
-    local file = sffs.open("test1.txt", "w");
-    local buffer = "0123456789012345678901234567890123456789";
-    for (local i = 0; i < (this.size / buffer.len() - 5); ++i)
-      file.write(buffer);
-
-    local ps = sffs._fat.get("test1.txt").pages;
-
-    file.close();
-
-    // double check that file has correct size
-    this.assertEqual(this.pages, ps.len() / 2);
-
-    local testPages = [];
-    // Check foreach page implementation
-    sffs._fat.forEachPage("test1.txt", function(p) {
-      testPages.push(p);
-    });
-
-    local cachedFileId = 0;
-    local cachedSpanId = 0;
-    // Check that all pages are sorted correctly
-    foreach(p in testPages) {
-      // read header of the page
-      hardware.spiflash.enable();
-      local buffer = hardware.spiflash.read(p, 4);
-      hardware.spiflash.disable();
-
-      local fileId = buffer.readn('w');
-      local spanId = buffer.readn('w');
-      // Check that file id is the same for all pages
-      this.assertTrue(cachedFileId == 0 || cachedFileId == fileId);
-      cachedFileId = fileId;
-      // check that span id is increasing
-      this.assertEqual(true, spanId >= cachedSpanId);
-      cachedSpanId = spanId;
+        // Scan the headers of each page, working out what is in each
+        for (local p = 0; p < pages; p++) {
+            local page = dim.start + (p * SPIFLASHFILESYSTEM_PAGE_SIZE);
+            local pageData = sffs._readPage(page, false);
+            info("ID: " + pageData.id + " SPAN: " + pageData.span +
+                " SIZE: " + pageData.size + " NAME: " + pageData.fname);
+        }
+        sffs._disable();
     }
-  }
-
-  //
-  // Helper debug method for debuggin current tests
-  //
-  function debugPrintFSDetails() {
-    sffs._enable();
-
-    // Scan the headers of each page, working out what is in each
-    for (local p = 0; p < this.pages; p++) {
-      local page = dim.start + (p * SPIFLASHFILESYSTEM_PAGE_SIZE);
-      local pageData = sffs._readPage(page, false);
-      this.info("ID: " + pageData.id + " SPAN: " + pageData.span +
-        " SIZE: " + pageData.size + " NAME: " + pageData.fname);
-    }
-    sffs._disable();
-  }
 }

--- a/tests/SffsFatInternalApi.device.test.nut
+++ b/tests/SffsFatInternalApi.device.test.nut
@@ -1,0 +1,334 @@
+// MIT License
+//
+// Copyright 2017 Electric Imp
+//
+// SPDX-License-Identifier: MIT
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO
+// EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES
+// OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+// ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+// "Promise" symbol is injected dependency from ImpUnit_Promise module,
+// while class being tested can be accessed from global scope as "::Promise".
+
+@include __PATH__ + "/BaseSFFS.device.nut"
+
+class SffsFatInternalApi extends BaseSffsTestCase {
+  _stats = null;
+  // extra parameters for test purpose
+  function setUpParameters() {
+    _stats = {
+      "bad": 0,
+      "used": 0,
+      "free": this.pages,
+      "erased": 0
+    };
+  }
+
+  //
+  // Check constructor on a newly created FS
+  //
+  function test01_constructor() {
+    // create a new FAT
+    local fat = SPIFlashFileSystem.FAT(this.sffs, this.pages);
+
+    // Check that all blocks are free
+    this.assertDeepEqual(fat.getStats(), _stats);
+
+    fat = SPIFlashFileSystem.FAT(this.sffs);
+    // FAT constructor without pages parameter
+    // should preform SCAN of the FS
+    this.assertDeepEqual(fat.getStats(), _stats);
+  }
+
+  //
+  // Constructor doesn't perform SCAN
+  // if the "pages" argument provided
+  //
+  function test02_constructor() {
+    createFile("test1.txt", "NOT EMPTY PAYLOAD");
+    // Create a new FAT over an existing FS
+    local fat = SPIFlashFileSystem.FAT(this.sffs, this.pages);
+
+    // Assume that all blocks are free
+    // because of second parameter provided to the constructor
+    this.assertDeepEqual(fat.getStats(), _stats);
+  }
+
+  // FAT constructor without pages parameter
+  // should preform SCAN of the FS
+  function test03_constructor() {
+    _stats.free -= 1;
+    _stats.used += 1;
+
+    local fat = SPIFlashFileSystem.FAT(this.sffs);
+    this.assertDeepEqual(fat.getStats(), _stats);
+  }
+
+  //
+  // Check that constructor does not recover
+  // deleted files
+  // Note: sffs.fat object
+  function test04_constructor() {
+    sffs.eraseFile("test1.txt");
+    _stats.used -= 1;
+    _stats.erased += 1;
+
+    local fat = SPIFlashFileSystem.FAT(sffs);
+    this.assertDeepEqual(fat.getStats(), _stats);
+  }
+
+  function test05_scan() {
+    createFile("test1.txt", "NOT EMPTY PAYLOAD");
+    createFile("test2.txt", "NOT EMPTY PAYLOAD");
+
+    sffs._fat.scan();
+    _stats.used += 2;
+    _stats.free -= 2;
+    // Total:
+    // 2 used pages
+    // 1 erased page
+    this.assertDeepEqual(sffs._fat.getStats(), _stats);
+  }
+
+  function test06_scanBadPage() {
+    // this mehod creates BAD pages on flash
+    makeBadPage();
+
+    _stats.bad += 1; // only one page was damaged
+    _stats.free -= 1;
+    sffs._fat.scan();
+    this.assertDeepEqual(_stats, sffs._fat.getStats());
+  }
+
+  function test07_get() {
+    local file = sffs._fat.get("test2.txt");
+    // it should be the same file
+    this.assertDeepEqual(file, sffs._fat.get(file.id));
+  }
+
+  //
+  // Test that get throw ERR_FILE_NOT_FOUND exception
+  //
+  function test08_get_throw() {
+    return Promise(function(ok, err) {
+      imp.wakeup(2, function() {
+        try {
+          local f = this.sffs._fat.get("file0.txt");
+          err("Expected file not found exception.");
+        } catch (e) {
+          ok();
+        }
+      }.bindenv(this));
+    }.bindenv(this));
+  }
+
+  //
+  // Note: FAT.getFileList method covered by SFFS.getFileList
+  //
+
+  //
+  // Search file ID by name:
+  // 1. successful search
+  // 2. throw ERR_FILE_NOT_FOUND
+  function test09_getFileId() {
+    local id = sffs._fat.getFileId("test1.txt")
+    this.assertEqual(true, id >= 0);
+
+    return Promise(function(ok, err) {
+      imp.wakeup(2, function() {
+        try {
+          local id = this.sffs._fat.get("file0.txt");
+          err("Expected file not found exception.");
+        } catch (e) {
+          ok();
+        }
+      }.bindenv(this));
+    }.bindenv(this));
+  }
+
+  //
+  // Note: FAT.fileExists method covered by SFFS.fileExists tests
+  //
+
+  // Note: get free page is based on random page selection
+  //       algorithm, therefore it could return a different
+  //       values on each call.
+  //       There is no page holding/reservation via this
+  //       method.
+  //
+  function test10_getFreePage() {
+    local dim = sffs.dimensions();
+    local page = sffs._fat.getFreePage();
+    // test that page in an available flash memory range
+    this.assertEqual(true, page >= dim.start && page < dim.end);
+
+    // Mark all pages as used to get ERR_NO_FREE_SPACE exception
+    return Promise(function(ok, err) {
+      imp.wakeup(2, function() {
+        try {
+          local page = sffs._fat.getFreePage();
+          while (page >= 0) {
+            sffs._fat.markPage(page, SPIFLASHFILESYSTEM_STATUS_USED);
+            page = sffs._fat.getFreePage();
+          }
+          err("Expected no free space exception.");
+        } catch (e) {
+          ok();
+        }
+      }.bindenv(this));
+    }.bindenv(this));
+  }
+
+  //
+  // Check that there is no problems to make a transition
+  // from each pages state to another one
+  // Note: current implementaion of the markPage doesn't have
+  //       state tracker for the transition from BAD->free
+  //       FREE->ERASED etc...
+  //       The purpose of this test is to catch if such
+  //       functionality will appear in the future
+  //
+  function test11_markPage() {
+    sffs.eraseAll();
+    local addr = sffs._fat.getFreePage();
+    return Promise(function(ok, err) {
+      imp.wakeup(2, function() {
+        try {
+          local flags = [SPIFLASHFILESYSTEM_STATUS_FREE,
+            SPIFLASHFILESYSTEM_STATUS_ERASED,
+            SPIFLASHFILESYSTEM_STATUS_USED,
+            SPIFLASHFILESYSTEM_STATUS_BAD
+          ];
+          for (local i = 0; i < 4; ++i) {
+            for (local j = 0; j < 4; ++j) {
+              sffs._fat.markPage(addr, flags[i]);
+              sffs._fat.markPage(addr, flags[j]);
+            }
+          }
+          ok();
+        } catch (e) {
+          err(e, "No exceptions expected. Please add testcase for markPage.");
+        }
+      }.bindenv(this));
+    }.bindenv(this));
+  }
+
+  //
+  // Create a very long file
+  // which consists of multiple pages
+  // but do not write a real data
+  //
+  function test12_addPage() {
+    // make an empty FS
+    sffs.eraseAll();
+    // reset an expected stats value
+    _stats = {
+      "bad": 0,
+      "used": 0,
+      "free": this.pages,
+      "erased": 0
+    };
+    // open file for writing
+    local filename = "test3.txt";
+    local file = sffs.open(filename, "w");
+
+    // Create file for all 64Kb
+    for (local i = 1; i <= pages; ++i) {
+      local page = sffs._fat.getFreePage();
+      sffs._fat.addPage(filename, page);
+      // addPage doesn't mark page ad used
+      // therefore we can get the same free page again and again
+      // to prevent it let's mark it as used
+      sffs._fat.markPage(page, SPIFLASHFILESYSTEM_STATUS_USED);
+      assertEqual(sffs._fat.getPageCount(filename), i);
+      sffs._fat.addSizeToLastSpan(filename, 123);
+    }
+    // close and remove file
+    file.close();
+    _stats = {
+      "bad": 0,
+      "used": this.pages,
+      "free": 0,
+      "erased": 0
+    };
+    // All blocks are used
+    this.assertDeepEqual(sffs._fat.getStats(), _stats);
+
+    sffs.eraseAll();
+  }
+
+  //
+  // Note: page order was implemented via 2-3 extra copy operations
+  //       but it is not so critical for a performance because sorting
+  //        should happen in scope of one file
+  //
+  function test13_pageOrderBySpan() {
+    // create one 64kb file
+    local file = sffs.open("test1.txt", "w");
+    local buffer = "0123456789012345678901234567890123456789";
+    for (local i = 0; i < (this.size / buffer.len() - 5); ++i)
+      file.write(buffer);
+
+    local ps = sffs._fat.get("test1.txt").pages;
+
+    file.close();
+
+    // double check that file has correct size
+    this.assertEqual(this.pages, ps.len() / 2);
+
+    local testPages = [];
+    // Check foreach page implementation
+    sffs._fat.forEachPage("test1.txt", function(p) {
+      testPages.push(p);
+    });
+
+    local cachedFileId = 0;
+    local cachedSpanId = 0;
+    // Check that all pages are sorted correctly
+    foreach(p in testPages) {
+      // read header of the page
+      hardware.spiflash.enable();
+      local buffer = hardware.spiflash.read(p, 4);
+      hardware.spiflash.disable();
+
+      local fileId = buffer.readn('w');
+      local spanId = buffer.readn('w');
+      // Check that file id is the same for all pages
+      this.assertTrue(cachedFileId == 0 || cachedFileId == fileId);
+      cachedFileId = fileId;
+      // check that span id is increasing
+      this.assertEqual(true, spanId >= cachedSpanId);
+      cachedSpanId = spanId;
+    }
+  }
+
+  //
+  // Helper debug method for debuggin current tests
+  //
+  function debugPrintFSDetails() {
+    sffs._enable();
+
+    // Scan the headers of each page, working out what is in each
+    for (local p = 0; p < this.pages; p++) {
+      local page = dim.start + (p * SPIFLASHFILESYSTEM_PAGE_SIZE);
+      local pageData = sffs._readPage(page, false);
+      this.info("ID: " + pageData.id + " SPAN: " + pageData.span +
+        " SIZE: " + pageData.size + " NAME: " + pageData.fname);
+    }
+    sffs._disable();
+  }
+}

--- a/tests/SffsFileApi.device.test.nut
+++ b/tests/SffsFileApi.device.test.nut
@@ -28,245 +28,283 @@ const MAX_SIZE_FILE_FILENAME = "max.txt";
 
 class SffsFileApi extends BaseSffsTestCase {
 
-  buffer = null;
-  iterations = 0;
-  maxHeaderSize = 0;
+    buffer = null;
+    iterations = 0;
+    maxHeaderSize = 0;
 
-  function setUpParameters() {
-    // payload buffer for tests
-    buffer = "0123456789012345678901234567890123456789";
-    // max iterations to ocupay all pages by a single file
-    iterations = this.pages * SPIFLASHFILESYSTEM_SECTOR_SIZE / buffer.len() - 10;
-    maxHeaderSize = SPIFLASHFILESYSTEM_HEADER_SIZE +
-      SPIFLASHFILESYSTEM_TIMESTAMP_SIZE;
-  }
+    function setUpParameters() {
+        // payload buffer for tests
+        buffer = "0123456789012345678901234567890123456789";
+        // max iterations to ocupay all pages by a single file
+        iterations = pages * SPIFLASHFILESYSTEM_SECTOR_SIZE / buffer.len() - 10;
+        maxHeaderSize = SPIFLASHFILESYSTEM_HEADER_SIZE +
+            SPIFLASHFILESYSTEM_TIMESTAMP_SIZE;
+    }
 
-    //
-    // Check that max size file
-    function test01_writeMaxPagesFile() {
-      local file = sffs.open(MAX_SIZE_FILE_FILENAME, "w");
-      for (local i = 0; i < iterations; ++i)
+        //
+        // Check that max size file
+        function test01_writeMaxPagesFile() {
+            local file = sffs.open(MAX_SIZE_FILE_FILENAME, "w");
+            for (local i = 0; i < iterations; ++i)
+                file.write(buffer);
+            // Check that all sectors are used
+            local space = sffs.getFreeSpace();
+            assertTrue(space.free + space.freeable    < SPIFLASHFILESYSTEM_SECTOR_SIZE);
+            file.close();
+            // Check that file size is correct
+            assertEqual(iterations * buffer.len(),
+                sffs.fileSize(MAX_SIZE_FILE_FILENAME));
+        }
+
+        function test02_maxFileSizeReading() {
+            local file = sffs.open(MAX_SIZE_FILE_FILENAME, "r");
+            // check that file has an expected max size
+            assertEqual(iterations * buffer.len(), file.len());
+
+            // Read and check all written payload data
+            for (local i = 0; i < iterations; i += 10) {
+                local payload = file.read(buffer.len());
+                assertDeepEqual(buffer, payload.readstring(buffer.len()));
+            }
+            // all file data readed the position should be EOF
+            assertTrue(file.tell() <= file.len());
+            file.close();
+        }
+
+        //
+        // Seek through the file randomly and check payload value
+        function test03_maxFileSizeSeeking() {
+            local file = sffs.open(MAX_SIZE_FILE_FILENAME, "r");
+            local buffer = "0123456789012345678901234567890123456789";
+            local iterations = pages * SPIFLASHFILESYSTEM_SECTOR_SIZE / buffer.len() - 10;
+            // random seek
+            for (local i = 0; i < iterations; i += 10) {
+                local randSeek = math.rand() % iterations;
+                randSeek = randSeek * buffer.len();
+                file.seek(randSeek);
+                assertEqual(randSeek, file.tell());
+                local payload = file.read(buffer.len());
+                assertEqual(buffer, payload.readstring(buffer.len()));
+                assertEqual(randSeek + buffer.len(), file.tell());
+            }
+            // move pointer to the end of file
+            file.seek(iterations * buffer.len())
+            // all file data readed the position should be EOF
+            assertTrue(file.eof());
+            // Check tell at the end of file
+            assertEqual(file.tell(), sffs.fileSize(MAX_SIZE_FILE_FILENAME));
+
+            // check seek and tell at file start position
+            file.seek(0);
+            assertEqual(file.tell(), 0);
+            file.close();
+        }
+
+    // seek, tell eof during file writing
+    function test04_writeFileAndSeek() {
+        // remove all files from the previous tests
+        sffs.eraseFiles();
+        // open file for write and seek
+        local file = sffs.open("test.txt", "w");
         file.write(buffer);
-      // Check that all sectors are used
-      local space = sffs.getFreeSpace();
-      assertTrue(space.free + space.freeable  < SPIFLASHFILESYSTEM_SECTOR_SIZE);
-      file.close();
-      // Check that file size is correct
-      this.assertEqual(iterations * buffer.len(),
-        sffs.fileSize(MAX_SIZE_FILE_FILENAME));
+        // tell return the read-pointer
+        // therefore it should be zero for a newly
+        // created file
+        assertEqual(0, file.tell());
+        local payload = file.read(buffer.len());
+        assertEqual(buffer.len(), file.tell());
+        assertEqual(file.eof(), true);
+        file.seek(0);
+        assertEqual(file.tell(), 0);
+        file.write(buffer);
+        file.seek(file.len());
+        assertTrue(file.eof());
+        assertEqual(file.tell(), buffer.len() * 2);
+        file.seek(file.len() - 1);
+        assertTrue(!file.eof());
+
+        file.close();
+        // there no way to read data from closed file
+        _checkApiExceptions(file);
     }
 
-    function test02_maxFileSizeReading() {
-      local file = sffs.open(MAX_SIZE_FILE_FILENAME, "r");
-      // check that file has an expected max size
-      this.assertEqual(iterations * buffer.len(), file.len());
 
-      // Read and check all written payload data
-      for (local i = 0; i < iterations; i += 10) {
-        local payload = file.read(buffer.len());
-        this.assertDeepEqual(buffer, payload.readstring(buffer.len()));
-      }
-      // all file data readed the position should be EOF
-      this.assertTrue(file.tell() <= file.len());
-      file.close();
+    // seek, tell eof after file close
+    function test05_fileClose() {
+        local file = sffs.open("test.txt", "r");
+        file.close();
+        _checkApiExceptions(file);
     }
 
     //
-    // Seek through the file randomly and check payload value
-    function test03_maxFileSizeSeeking() {
-      local file = sffs.open(MAX_SIZE_FILE_FILENAME, "r");
-      local buffer = "0123456789012345678901234567890123456789";
-      local iterations = this.pages * SPIFLASHFILESYSTEM_SECTOR_SIZE / buffer.len() - 10;
-      // random seek
-      for (local i = 0; i < iterations; i += 10) {
-        local randSeek = math.rand() % iterations;
-        randSeek = randSeek * buffer.len();
-        file.seek(randSeek);
-        this.assertEqual(randSeek, file.tell());
-        local payload = file.read(buffer.len());
-        this.assertEqual(buffer, payload.readstring(buffer.len()));
-        this.assertEqual(randSeek + buffer.len(), file.tell());
-      }
-      // move pointer to the end of file
-      file.seek(iterations * buffer.len())
-      // all file data readed the position should be EOF
-      this.assertTrue(file.eof());
-      // Check tell at the end of file
-      this.assertEqual(file.tell(), sffs.fileSize(MAX_SIZE_FILE_FILENAME));
+    // helper method to avoid code duplication
+    // for write and read use-cases
+    function _checkApiExceptions(file) {
+        // there no way to perform operations with closed file
+        try {
+          file.tell();
+          assertTrue(false, "Exception expected");
+        } catch (e) {
+          // do nothing, expected behavior
+        }
 
-      // check seek and tell at file start position
-      file.seek(0);
-      this.assertEqual(file.tell(), 0);
-      file.close();
+        try {
+          file.seek(0);
+          assertTrue(false, "Exception expected");
+        } catch (e) {
+          // do nothing, expected behavior
+        }
+
+        try {
+          file.created();
+          assertTrue(false, "Exception expected");
+        } catch (e) {
+          // do nothing, expected behavior
+        }
+
+        try {
+          file.eof();
+          assertTrue(false, "Exception expected");
+        } catch (e) {
+          // do nothing, expected behavior
+        }
+
+        try {
+          file.read(buffer.len());
+          assertTrue(false, "Exception expected");
+        } catch (e) {
+          // do nothing, expected behavior
+        }
+
+        try {
+          file.write(buffer);
+          assertTrue(false, "Exception expected");
+        } catch (e) {
+          // do nothing, expected behavior
+        }
     }
 
-  // seek, tell eof during file writing
-  function test04_writeFileAndSeek() {
-    // remove all files from the previous tests
-    sffs.eraseFiles();
-    // open file for write and seek
-    local file = sffs.open("test.txt", "w");
-    file.write(buffer);
-    // tell return the read-pointer
-    // therefore it should be zero for a newly
-    // created file
-    this.assertEqual(0, file.tell());
-    local payload = file.read(buffer.len());
-    this.assertEqual(buffer.len(), file.tell());
-    this.assertEqual(file.eof(), true);
-    file.seek(0);
-    this.assertEqual(file.tell(), 0);
-    file.write(buffer);
-    file.seek(file.len());
-    this.assertTrue(file.eof());
-    this.assertEqual(file.tell(), buffer.len() * 2);
-    file.seek(file.len() - 1);
-    this.assertTrue(!file.eof());
-
-    file.close();
-    // there no way to read data from closed file
-    this.assertEqual(file.seek(0).tell(), 0);
-    // try to read data from closed file
-    payload = file.read(buffer.len());
-    this.assertEqual(file.tell(), buffer.len());
-    this.assertEqual(file.seek(file.len()).tell(), file.len());
-    this.assertTrue(file.eof());
-  }
-
-
-  // seek, tell eof after file close
-  function test05_fileClose() {
-    local file = sffs.open("test.txt", "r");
-    file.close();
-
-    this.assertEqual(file.tell(), 0);
-    // there no way to read data from closed file
-    this.assertEqual(file.seek(0).tell(), 0);
-    // try to read data from closed file
-    local payload = file.read(buffer.len());
-    this.assertEqual(file.tell(), buffer.len());
-    this.assertEqual(file.seek(file.len()).tell(), file.len());
-    this.assertTrue(file.eof());
-  }
-
-  //
-  // concurrent access to the last available free or erazed page
-  //
-  // what should happen when there is only one free
-  // page left but we are writing 2 file which need
-  // a new free page?
-  function test06_concurentAccessToTheLastFreePage() {
-    sffs.eraseFiles();
-    for (local i = 0; i < this.pages - 3; ++i)
-      createFile("file" + i + ".txt", "some payload");
-    local stats = sffs._fat.getStats();
-    // expecting that only 3 pages are available
-    this.assertEqual(3, stats.free + stats.erased);
     //
-    // Length of the filenames are different to prevent
-    // writing of the same payload at the same
-    // address
-    local filename = "test2.txt";
-    local file1 = sffs.open("test1_diff.txt", "w");
-    local file2 = sffs.open(filename, "w");
-    // each file has heard therefore it is enough
-    // to write page size payload to each file
-    // to create an concurent access use-case
-    for (local i = 0; i < SPIFLASHFILESYSTEM_SECTOR_SIZE / buffer.len(); ++i) {
-      file1.write(buffer);
-      // an attemption to request next sector
-      try {
-        file2.write(buffer);
-      } catch (e) {
-        local expectedSize = SPIFLASHFILESYSTEM_SECTOR_SIZE -
-          maxHeaderSize - filename.len() + 1;
-        // Trying to write more data then available space
-        this.assertTrue((i + 1) * buffer.len() > expectedSize);
-        // Check that number of written data less then available space
-        this.assertTrue(file2.len() < expectedSize);
-      }
+    // concurrent access to the last available free or erazed page
+    //
+    // what should happen when there is only one free
+    // page left but we are writing 2 file which need
+    // a new free page?
+    function test06_concurentAccessToTheLastFreePage() {
+        sffs.eraseFiles();
+        for (local i = 0; i < pages - 3; ++i)
+            createFile("file" + i + ".txt", "some payload");
+        local stats = sffs._fat.getStats();
+        // expecting that only 3 pages are available
+        assertEqual(3, stats.free + stats.erased);
+        //
+        // Length of the filenames are different to prevent
+        // writing of the same payload at the same
+        // address
+        local filename = "test2.txt";
+        local file1 = sffs.open("test1_diff.txt", "w");
+        local file2 = sffs.open(filename, "w");
+        // each file has heard therefore it is enough
+        // to write page size payload to each file
+        // to create an concurent access use-case
+        for (local i = 0; i < SPIFLASHFILESYSTEM_SECTOR_SIZE / buffer.len(); ++i) {
+            file1.write(buffer);
+            // an attemption to request next sector
+            try {
+                file2.write(buffer);
+            } catch (e) {
+                local expectedSize = SPIFLASHFILESYSTEM_SECTOR_SIZE -
+                    maxHeaderSize - filename.len() + 1;
+                // Trying to write more data then available space
+                assertTrue((i + 1) * buffer.len() > expectedSize);
+                // Check that number of written data less then available space
+                assertTrue(file2.len() < expectedSize);
+            }
+        }
+        file1.close();
+        file2.close();
+
+        // Check filesize after the previous test which
+        // should be finished with exception
+        local fs1 = sffs.fileSize("test1_diff.txt");
+        local fs2 = sffs.fileSize("test2.txt");
+        // expecting that first file catched free pages
+        // but second one failed with it
+        assertTrue(fs1 > fs2);
     }
-    file1.close();
-    file2.close();
-  }
 
-  // Check filesize after the previous test which
-  // should be finished with exception
-  function test07_checkFileSize() {
-    local fs1 = sffs.fileSize("test1_diff.txt");
-    local fs2 = sffs.fileSize("test2.txt");
-    // expecting that first file catched free pages
-    // but second one failed with it
-    this.assertTrue(fs1 > fs2);
-  }
-
-  // check that seel of one file
-  // doesn't affect seek method of another file
-  function test08_multipleFilesSeek() {
-    local file1 = sffs.open("test1_diff.txt", "r");
-    local file2 = sffs.open("test2.txt", "r");
-    for (local i = 0; i < 10; ++i) {
-      local s1 = math.rand() % file1.len();
-      file1.seek(s1);
-      local s2 = math.rand() % file2.len();
-      file2.seek(s2);
-      this.assertEqual(s1, file1.tell());
-      this.assertEqual(s2, file2.tell());
+    // check that seel of one file
+    // doesn't affect seek method of another file
+    function test07_multipleFilesSeek() {
+        local file1 = sffs.open("test1_diff.txt", "r");
+        local file2 = sffs.open("test2.txt", "r");
+        for (local i = 0; i < 10; ++i) {
+            local s1 = math.rand() % file1.len();
+            file1.seek(s1);
+            local s2 = math.rand() % file2.len();
+            file2.seek(s2);
+            assertEqual(s1, file1.tell());
+            assertEqual(s2, file2.tell());
+        }
+        // Test eof dependency too
+        local eofState = file2.eof();
+        file1.seek(file1.len());
+        assertEqual(eofState, file2.eof());
+        file1.seek(0);
+        assertEqual(eofState, file2.eof());
+        // Close
+        file1.close();
+        file2.close();
     }
-    // Test eof dependency too
-    local eofState = file2.eof();
-    file1.seek(file1.len());
-    this.assertEqual(eofState, file2.eof());
-    file1.seek(0);
-    this.assertEqual(eofState, file2.eof());
-    // Close
-    file1.close();
-    file2.close();
-  }
 
-  // Test reading data at the eof
-  function test09_eofRead() {
-    local file = sffs.open("test1_diff.txt", "r");
-    // seek to the eof
-    file.seek(file.len());
-    local payload = file.read(100);
-    assertEqual(0, payload.len(), "Expected an empty payload");
-    file.close();
-  }
-
-  // Test seek over the eof
-  function test10_eofSeek() {
-    local file = sffs.open("test1_diff.txt", "r");
-    // seek eof + 10
-    file.seek(file.len() + 10);
-    assertTrue(file.eof(), "Wrong position seek");
-    local payload = file.read(10);
-    assertEqual(0, payload.len(), "Unexpected payload len at the EOF");
-    file.close();
-  }
-
-  // Empty file's seek and tell and eof
-  function test11_emptyFile() {
-    // erase all files on FS
-    sffs.eraseFiles();
-    // create an empty file without any payload
-    createFile("test1.txt");
-    local file = sffs.open("test1.txt", "r");
-    assertEqual(0, file.tell());
-    assertEqual(true, file.eof());
-    local seekPass = false;
-    try {
-      // it should be possible to seek at the same position
-      file.seek(0);
-      seekPass = true;
-      // check that possition is correct
-      assertEqual(0, file.tell());
-      // this seek should throw an exception
-      file.seek(1);
-    } catch (e) {
-      assertEqual(seekPass, true,
-        "Expected that it is possible to seek on 0 for an empt file");
+    // Test reading data at the eof
+    function test08_eofRead() {
+        local file = sffs.open("test1_diff.txt", "r");
+        // seek to the eof
+        file.seek(file.len());
+        local payload = file.read(100);
+        assertEqual(0, payload.len(), "Expected an empty payload");
+        file.close();
     }
-    file.close();
-  }
+
+    // Test seek over the eof
+    function test09_eofSeek() {
+        local file = sffs.open("test1_diff.txt", "r");
+        // seek eof + 10
+        try {
+            file.seek(file.len() + 10);
+            assertTrue(false, "Exception expected on invalid paramter.");
+        } catch(e) {
+            // Expected exception
+        }
+        // seek to the end of file
+        local payload = file.seek(file.len()).read(10);
+        assertEqual(0, payload.len(), "Unexpected payload length at the EOF");
+        file.close();
+    }
+
+    // Empty file's seek and tell and eof
+    function test10_emptyFile() {
+        // erase all files on FS
+        sffs.eraseFiles();
+        // create an empty file without any payload
+        createFile("test1.txt");
+        local file = sffs.open("test1.txt", "r");
+        assertEqual(0, file.tell());
+        assertEqual(true, file.eof());
+        local seekPass = false;
+        try {
+            // it should be possible to seek at the same position
+            file.seek(0);
+            seekPass = true;
+            // check that possition is correct
+            assertEqual(0, file.tell());
+            // this seek should throw an exception
+            file.seek(1);
+        } catch (e) {
+            assertEqual(seekPass, true,
+                "Expected that it is possible to seek on 0 for an empty file");
+        }
+        file.close();
+    }
 }

--- a/tests/SffsFileApi.device.test.nut
+++ b/tests/SffsFileApi.device.test.nut
@@ -1,0 +1,272 @@
+// MIT License
+//
+// Copyright 2017 Electric Imp
+//
+// SPDX-License-Identifier: MIT
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO
+// EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES
+// OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+// ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+
+@include __PATH__ + "/BaseSFFS.device.nut"
+
+const MAX_SIZE_FILE_FILENAME = "max.txt";
+
+class SffsFileApi extends BaseSffsTestCase {
+
+  buffer = null;
+  iterations = 0;
+  maxHeaderSize = 0;
+
+  function setUpParameters() {
+    // payload buffer for tests
+    buffer = "0123456789012345678901234567890123456789";
+    // max iterations to ocupay all pages by a single file
+    iterations = this.pages * SPIFLASHFILESYSTEM_SECTOR_SIZE / buffer.len() - 10;
+    maxHeaderSize = SPIFLASHFILESYSTEM_HEADER_SIZE +
+      SPIFLASHFILESYSTEM_TIMESTAMP_SIZE;
+  }
+
+    //
+    // Check that max size file
+    function test01_writeMaxPagesFile() {
+      local file = sffs.open(MAX_SIZE_FILE_FILENAME, "w");
+      for (local i = 0; i < iterations; ++i)
+        file.write(buffer);
+      // Check that all sectors are used
+      local space = sffs.getFreeSpace();
+      assertTrue(space.free + space.freeable  < SPIFLASHFILESYSTEM_SECTOR_SIZE);
+      file.close();
+      // Check that file size is correct
+      this.assertEqual(iterations * buffer.len(),
+        sffs.fileSize(MAX_SIZE_FILE_FILENAME));
+    }
+
+    function test02_maxFileSizeReading() {
+      local file = sffs.open(MAX_SIZE_FILE_FILENAME, "r");
+      // check that file has an expected max size
+      this.assertEqual(iterations * buffer.len(), file.len());
+
+      // Read and check all written payload data
+      for (local i = 0; i < iterations; i += 10) {
+        local payload = file.read(buffer.len());
+        this.assertDeepEqual(buffer, payload.readstring(buffer.len()));
+      }
+      // all file data readed the position should be EOF
+      this.assertTrue(file.tell() <= file.len());
+      file.close();
+    }
+
+    //
+    // Seek through the file randomly and check payload value
+    function test03_maxFileSizeSeeking() {
+      local file = sffs.open(MAX_SIZE_FILE_FILENAME, "r");
+      local buffer = "0123456789012345678901234567890123456789";
+      local iterations = this.pages * SPIFLASHFILESYSTEM_SECTOR_SIZE / buffer.len() - 10;
+      // random seek
+      for (local i = 0; i < iterations; i += 10) {
+        local randSeek = math.rand() % iterations;
+        randSeek = randSeek * buffer.len();
+        file.seek(randSeek);
+        this.assertEqual(randSeek, file.tell());
+        local payload = file.read(buffer.len());
+        this.assertEqual(buffer, payload.readstring(buffer.len()));
+        this.assertEqual(randSeek + buffer.len(), file.tell());
+      }
+      // move pointer to the end of file
+      file.seek(iterations * buffer.len())
+      // all file data readed the position should be EOF
+      this.assertTrue(file.eof());
+      // Check tell at the end of file
+      this.assertEqual(file.tell(), sffs.fileSize(MAX_SIZE_FILE_FILENAME));
+
+      // check seek and tell at file start position
+      file.seek(0);
+      this.assertEqual(file.tell(), 0);
+      file.close();
+    }
+
+  // seek, tell eof during file writing
+  function test04_writeFileAndSeek() {
+    // remove all files from the previous tests
+    sffs.eraseFiles();
+    // open file for write and seek
+    local file = sffs.open("test.txt", "w");
+    file.write(buffer);
+    // tell return the read-pointer
+    // therefore it should be zero for a newly
+    // created file
+    this.assertEqual(0, file.tell());
+    local payload = file.read(buffer.len());
+    this.assertEqual(buffer.len(), file.tell());
+    this.assertEqual(file.eof(), true);
+    file.seek(0);
+    this.assertEqual(file.tell(), 0);
+    file.write(buffer);
+    file.seek(file.len());
+    this.assertTrue(file.eof());
+    this.assertEqual(file.tell(), buffer.len() * 2);
+    file.seek(file.len() - 1);
+    this.assertTrue(!file.eof());
+
+    file.close();
+    // there no way to read data from closed file
+    this.assertEqual(file.seek(0).tell(), 0);
+    // try to read data from closed file
+    payload = file.read(buffer.len());
+    this.assertEqual(file.tell(), buffer.len());
+    this.assertEqual(file.seek(file.len()).tell(), file.len());
+    this.assertTrue(file.eof());
+  }
+
+
+  // seek, tell eof after file close
+  function test05_fileClose() {
+    local file = sffs.open("test.txt", "r");
+    file.close();
+
+    this.assertEqual(file.tell(), 0);
+    // there no way to read data from closed file
+    this.assertEqual(file.seek(0).tell(), 0);
+    // try to read data from closed file
+    local payload = file.read(buffer.len());
+    this.assertEqual(file.tell(), buffer.len());
+    this.assertEqual(file.seek(file.len()).tell(), file.len());
+    this.assertTrue(file.eof());
+  }
+
+  //
+  // concurrent access to the last available free or erazed page
+  //
+  // what should happen when there is only one free
+  // page left but we are writing 2 file which need
+  // a new free page?
+  function test06_concurentAccessToTheLastFreePage() {
+    sffs.eraseFiles();
+    for (local i = 0; i < this.pages - 3; ++i)
+      createFile("file" + i + ".txt", "some payload");
+    local stats = sffs._fat.getStats();
+    // expecting that only 3 pages are available
+    this.assertEqual(3, stats.free + stats.erased);
+    //
+    // Length of the filenames are different to prevent
+    // writing of the same payload at the same
+    // address
+    local filename = "test2.txt";
+    local file1 = sffs.open("test1_diff.txt", "w");
+    local file2 = sffs.open(filename, "w");
+    // each file has heard therefore it is enough
+    // to write page size payload to each file
+    // to create an concurent access use-case
+    for (local i = 0; i < SPIFLASHFILESYSTEM_SECTOR_SIZE / buffer.len(); ++i) {
+      file1.write(buffer);
+      // an attemption to request next sector
+      try {
+        file2.write(buffer);
+      } catch (e) {
+        local expectedSize = SPIFLASHFILESYSTEM_SECTOR_SIZE -
+          maxHeaderSize - filename.len() + 1;
+        // Trying to write more data then available space
+        this.assertTrue((i + 1) * buffer.len() > expectedSize);
+        // Check that number of written data less then available space
+        this.assertTrue(file2.len() < expectedSize);
+      }
+    }
+    file1.close();
+    file2.close();
+  }
+
+  // Check filesize after the previous test which
+  // should be finished with exception
+  function test07_checkFileSize() {
+    local fs1 = sffs.fileSize("test1_diff.txt");
+    local fs2 = sffs.fileSize("test2.txt");
+    // expecting that first file catched free pages
+    // but second one failed with it
+    this.assertTrue(fs1 > fs2);
+  }
+
+  // check that seel of one file
+  // doesn't affect seek method of another file
+  function test08_multipleFilesSeek() {
+    local file1 = sffs.open("test1_diff.txt", "r");
+    local file2 = sffs.open("test2.txt", "r");
+    for (local i = 0; i < 10; ++i) {
+      local s1 = math.rand() % file1.len();
+      file1.seek(s1);
+      local s2 = math.rand() % file2.len();
+      file2.seek(s2);
+      this.assertEqual(s1, file1.tell());
+      this.assertEqual(s2, file2.tell());
+    }
+    // Test eof dependency too
+    local eofState = file2.eof();
+    file1.seek(file1.len());
+    this.assertEqual(eofState, file2.eof());
+    file1.seek(0);
+    this.assertEqual(eofState, file2.eof());
+    // Close
+    file1.close();
+    file2.close();
+  }
+
+  // Test reading data at the eof
+  function test09_eofRead() {
+    local file = sffs.open("test1_diff.txt", "r");
+    // seek to the eof
+    file.seek(file.len());
+    local payload = file.read(100);
+    assertEqual(0, payload.len(), "Expected an empty payload");
+    file.close();
+  }
+
+  // Test seek over the eof
+  function test10_eofSeek() {
+    local file = sffs.open("test1_diff.txt", "r");
+    // seek eof + 10
+    file.seek(file.len() + 10);
+    assertTrue(file.eof(), "Wrong position seek");
+    local payload = file.read(10);
+    assertEqual(0, payload.len(), "Unexpected payload len at the EOF");
+    file.close();
+  }
+
+  // Empty file's seek and tell and eof
+  function test11_emptyFile() {
+    // erase all files on FS
+    sffs.eraseFiles();
+    // create an empty file without any payload
+    createFile("test1.txt");
+    local file = sffs.open("test1.txt", "r");
+    assertEqual(0, file.tell());
+    assertEqual(true, file.eof());
+    local seekPass = false;
+    try {
+      // it should be possible to seek at the same position
+      file.seek(0);
+      seekPass = true;
+      // check that possition is correct
+      assertEqual(0, file.tell());
+      // this seek should throw an exception
+      file.seek(1);
+    } catch (e) {
+      assertEqual(seekPass, true,
+        "Expected that it is possible to seek on 0 for an empt file");
+    }
+    file.close();
+  }
+}

--- a/tests/SffsLimitsVerification.device.test.nut
+++ b/tests/SffsLimitsVerification.device.test.nut
@@ -27,136 +27,136 @@
 @include __PATH__ + "/BaseSFFS.device.nut"
 
 class SffsLimitsVerification extends BaseSffsTestCase {
-  fileNames = [];
+    fileNames = [];
 
-  function setUpParameters() {
-    for (local i = 1; i <= this.pages; i++) {
-      local filename = "file" + i + ".txt";
-      this.fileNames.push(filename);
-    }
-  }
-
-  //
-  // Test .fileList() limits
-  //
-  function test01_FileListLimit() {
-    //
-    // there are 16 sectors/pages by 4Kb on the 64kb flash
-    // and each file is required 1 page/sector
-    //
-    for (local i = 1; i <= this.pages; i++) {
-      // Create an empty file but it should allocate
-      // one page at least
-      local filename = this.fileNames[i - 1];
-      createFile(filename, "Some payload");
-
-      // check that it's listed
-      local files = this.sffs.getFileList();
-      this.assertEqual(i, files.len());
-
-      // check the rest of the files data structure
-      local created = files[i - 1]["created"];
-      foreach(f in files)
-      if (f.fname == filename)
-        this.assertEqual(f.id, (1 + (i - 1) * 2));
-    }
-  }
-  //
-  // Test - no more space on flash for a new file
-  // @methods: .fileList(), open(), close()
-  //
-  function test02_FileListFullFlash() {
-    return Promise(function(ok, err) {
-      imp.wakeup(2, function() {
-        try {
-          this.sffs.open(filename, "w").close();
-          err("Expected: no mo space available exception");
-        } catch (e) {
-          // no more space on the flash
-          ok();
+    function setUpParameters() {
+        for (local i = 1; i <= pages; i++) {
+            local filename = "file" + i + ".txt";
+            fileNames.push(filename);
         }
-      }.bindenv(this));
-    }.bindenv(this));
-  }
+    }
 
-  //
-  // Test ordering of files with
-  // maximum number of files
-  // Note: there is no specified sorting method for the files
-  //       with the same create time
-  //
-  function test03_FileListOrdering() {
-    return Promise(function(ok, err) {
-      imp.wakeup(2, function() {
-        try {
-          local files;
+    //
+    // Test .fileList() limits
+    //
+    function test01_FileListLimit() {
+        //
+        // there are 16 sectors/pages by 4Kb on the 64kb flash
+        // and each file is required 1 page/sector
+        //
+        for (local i = 1; i <= pages; i++) {
+            // Create an empty file but it should allocate
+            // one page at least
+            local filename = fileNames[i - 1];
+            createFile(filename, "Some payload");
 
-          // list files with alphabetic ordering by name
-          files = this.sffs.getFileList( /* orderByDate=false */ );
+            // check that it's listed
+            local files = sffs.getFileList();
+            assertEqual(i, files.len());
 
-          this.assertEqual("file1.txt", files[0].fname,
-            "getFileList(false) is expected to sort files by name");
-
-          // list files ordering by date, asc
-          files = this.sffs.getFileList(true /* orderByDate=true */ );
-
-          // Check that file list was sorted by "created"
-          local created = 0;
-          foreach(m in files) {
-            this.assertTrue(created <= m.created,
-              "getFileList(true) is expected to sort files by creation date");
-            created = m.created;
-          }
-          ok();
-        } catch (e) {
-          err(e);
+            // check the rest of the files data structure
+            local created = files[i - 1]["created"];
+            foreach(f in files)
+            if (f.fname == filename)
+                assertEqual(f.id, (1 + (i - 1) * 2));
         }
-      }.bindenv(this));
-    }.bindenv(this));
-  }
-
-  //
-  // Test maximum open file descriptors for reading
-  // 1. Open all files descriptors
-  // 2. Check that all descriptors are opened
-  // 3. Close all descriptors
-  // 4. Check that all descriptors are closed
-  //
-  function test04_multipleFilesReadDescriptors() {
-    local descriptors = [];
-    // Open max number of files
-    foreach(filename in fileNames) {
-      // open file
-      descriptors.push(this.sffs.open(filename, "r"));
     }
-    // check that all files are opened
-    foreach(filename in fileNames) {
-      // open file
-      this.assertEqual(true, this.sffs.isFileOpen(filename));
-    }
-    // close all files descriptors
-    foreach(f in descriptors)
-    f.close();
-
-    // Check that all descriptors are closed correctly
-    foreach(filename in fileNames) {
-      // open file
-      this.assertEqual(false, this.sffs.isFileOpen(filename));
-    }
-  }
-
-  //
-  // Test .eraseFile()
-  // Test erase files one by one
-  //
-  function test05_EraseFile() {
-    foreach(filename in fileNames) {
-      this.sffs.eraseFile(filename);
-      this.assertEqual(false, this.sffs.fileExists(filename));
+    //
+    // Test - no more space on flash for a new file
+    // @methods: .fileList(), open(), close()
+    //
+    function test02_FileListFullFlash() {
+        return Promise(function(ok, err) {
+            imp.wakeup(2, function() {
+                try {
+                    sffs.open(filename, "w").close();
+                    err("Expected: no mo space available exception");
+                } catch (e) {
+                    // no more space on the flash
+                    ok();
+                }
+            }.bindenv(this));
+        }.bindenv(this));
     }
 
-    // check that there no file on the FS
-    local files = this.sffs.getFileList();
-    this.assertEqual(0, files.len());
-  }
+    //
+    // Test ordering of files with
+    // maximum number of files
+    // Note: there is no specified sorting method for the files
+    //             with the same create time
+    //
+    function test03_FileListOrdering() {
+        return Promise(function(ok, err) {
+            imp.wakeup(2, function() {
+                try {
+                    local files;
+
+                    // list files with alphabetic ordering by name
+                    files = sffs.getFileList( /* orderByDate=false */ );
+
+                    assertEqual("file1.txt", files[0].fname,
+                        "getFileList(false) is expected to sort files by name");
+
+                    // list files ordering by date, asc
+                    files = sffs.getFileList(true /* orderByDate=true */ );
+
+                    // Check that file list was sorted by "created"
+                    local created = 0;
+                    foreach(m in files) {
+                        assertTrue(created <= m.created,
+                            "getFileList(true) is expected to sort files by creation date");
+                        created = m.created;
+                    }
+                    ok();
+                } catch (e) {
+                    err(e);
+                }
+            }.bindenv(this));
+        }.bindenv(this));
+    }
+
+    //
+    // Test maximum open file descriptors for reading
+    // 1. Open all files descriptors
+    // 2. Check that all descriptors are opened
+    // 3. Close all descriptors
+    // 4. Check that all descriptors are closed
+    //
+    function test04_multipleFilesReadDescriptors() {
+        local descriptors = [];
+        // Open max number of files
+        foreach(filename in fileNames) {
+            // open file
+            descriptors.push(sffs.open(filename, "r"));
+        }
+        // check that all files are opened
+        foreach(filename in fileNames) {
+            // open file
+            assertEqual(true, sffs.isFileOpen(filename));
+        }
+        // close all files descriptors
+        foreach(f in descriptors)
+        f.close();
+
+        // Check that all descriptors are closed correctly
+        foreach(filename in fileNames) {
+            // open file
+            assertEqual(false, sffs.isFileOpen(filename));
+        }
+    }
+
+    //
+    // Test .eraseFile()
+    // Test erase files one by one
+    //
+    function test05_EraseFile() {
+        foreach(filename in fileNames) {
+            sffs.eraseFile(filename);
+            assertEqual(false, sffs.fileExists(filename));
+        }
+
+        // check that there no file on the FS
+        local files = sffs.getFileList();
+        assertEqual(0, files.len());
+    }
 }

--- a/tests/SffsLimitsVerification.device.test.nut
+++ b/tests/SffsLimitsVerification.device.test.nut
@@ -1,0 +1,162 @@
+// MIT License
+//
+// Copyright 2017 Electric Imp
+//
+// SPDX-License-Identifier: MIT
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO
+// EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES
+// OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+// ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+// "Promise" symbol is injected dependency from ImpUnit_Promise module,
+// while class being tested can be accessed from global scope as "::Promise".
+
+@include __PATH__ + "/BaseSFFS.device.nut"
+
+class SffsLimitsVerification extends BaseSffsTestCase {
+  fileNames = [];
+
+  function setUpParameters() {
+    for (local i = 1; i <= this.pages; i++) {
+      local filename = "file" + i + ".txt";
+      this.fileNames.push(filename);
+    }
+  }
+
+  //
+  // Test .fileList() limits
+  //
+  function test01_FileListLimit() {
+    //
+    // there are 16 sectors/pages by 4Kb on the 64kb flash
+    // and each file is required 1 page/sector
+    //
+    for (local i = 1; i <= this.pages; i++) {
+      // Create an empty file but it should allocate
+      // one page at least
+      local filename = this.fileNames[i - 1];
+      createFile(filename, "Some payload");
+
+      // check that it's listed
+      local files = this.sffs.getFileList();
+      this.assertEqual(i, files.len());
+
+      // check the rest of the files data structure
+      local created = files[i - 1]["created"];
+      foreach(f in files)
+      if (f.fname == filename)
+        this.assertEqual(f.id, (1 + (i - 1) * 2));
+    }
+  }
+  //
+  // Test - no more space on flash for a new file
+  // @methods: .fileList(), open(), close()
+  //
+  function test02_FileListFullFlash() {
+    return Promise(function(ok, err) {
+      imp.wakeup(2, function() {
+        try {
+          this.sffs.open(filename, "w").close();
+          err("Expected: no mo space available exception");
+        } catch (e) {
+          // no more space on the flash
+          ok();
+        }
+      }.bindenv(this));
+    }.bindenv(this));
+  }
+
+  //
+  // Test ordering of files with
+  // maximum number of files
+  // Note: there is no specified sorting method for the files
+  //       with the same create time
+  //
+  function test03_FileListOrdering() {
+    return Promise(function(ok, err) {
+      imp.wakeup(2, function() {
+        try {
+          local files;
+
+          // list files with alphabetic ordering by name
+          files = this.sffs.getFileList( /* orderByDate=false */ );
+
+          this.assertEqual("file1.txt", files[0].fname,
+            "getFileList(false) is expected to sort files by name");
+
+          // list files ordering by date, asc
+          files = this.sffs.getFileList(true /* orderByDate=true */ );
+
+          // Check that file list was sorted by "created"
+          local created = 0;
+          foreach(m in files) {
+            this.assertTrue(created <= m.created,
+              "getFileList(true) is expected to sort files by creation date");
+            created = m.created;
+          }
+          ok();
+        } catch (e) {
+          err(e);
+        }
+      }.bindenv(this));
+    }.bindenv(this));
+  }
+
+  //
+  // Test maximum open file descriptors for reading
+  // 1. Open all files descriptors
+  // 2. Check that all descriptors are opened
+  // 3. Close all descriptors
+  // 4. Check that all descriptors are closed
+  //
+  function test04_multipleFilesReadDescriptors() {
+    local descriptors = [];
+    // Open max number of files
+    foreach(filename in fileNames) {
+      // open file
+      descriptors.push(this.sffs.open(filename, "r"));
+    }
+    // check that all files are opened
+    foreach(filename in fileNames) {
+      // open file
+      this.assertEqual(true, this.sffs.isFileOpen(filename));
+    }
+    // close all files descriptors
+    foreach(f in descriptors)
+    f.close();
+
+    // Check that all descriptors are closed correctly
+    foreach(filename in fileNames) {
+      // open file
+      this.assertEqual(false, this.sffs.isFileOpen(filename));
+    }
+  }
+
+  //
+  // Test .eraseFile()
+  // Test erase files one by one
+  //
+  function test05_EraseFile() {
+    foreach(filename in fileNames) {
+      this.sffs.eraseFile(filename);
+      this.assertEqual(false, this.sffs.fileExists(filename));
+    }
+
+    // check that there no file on the FS
+    local files = this.sffs.getFileList();
+    this.assertEqual(0, files.len());
+  }
+}

--- a/tests/SffsLimitsVerification.device.test.nut
+++ b/tests/SffsLimitsVerification.device.test.nut
@@ -94,8 +94,10 @@ class SffsLimitsVerification extends BaseSffsTestCase {
                     // list files with alphabetic ordering by name
                     files = sffs.getFileList( /* orderByDate=false */ );
 
-                    assertEqual("file1.txt", files[0].fname,
-                        "getFileList(false) is expected to sort files by name");
+                    if ("file1.txt" != files[0].fname) {
+                        err("getFileList(false) is expected to sort files by name");
+                        return;
+                    }
 
                     // list files ordering by date, asc
                     files = sffs.getFileList(true /* orderByDate=true */ );
@@ -103,8 +105,10 @@ class SffsLimitsVerification extends BaseSffsTestCase {
                     // Check that file list was sorted by "created"
                     local created = 0;
                     foreach(m in files) {
-                        assertTrue(created <= m.created,
-                            "getFileList(true) is expected to sort files by creation date");
+                        if (created > m.created) {
+                            err("getFileList(true) is expected to sort files by creation date");
+                            return;
+                        }
                         created = m.created;
                     }
                     ok();

--- a/tests/SffsMarkedBlocks.device.test.nut
+++ b/tests/SffsMarkedBlocks.device.test.nut
@@ -25,151 +25,148 @@
 @include __PATH__ + "/BaseSFFS.device.nut"
 
 class SffsMarkedBlocks extends BaseSffsTestCase {
-  _stats = null;
+    _stats = null;
 
-  function checkStats(stats) {
-    local s = this.sffs._fat.getStats();
-    this.assertDeepEqual(stats, s);
-  }
-
-  function test01_afterErase() {
-    _stats = {
-      "bad": 0,
-      "used": 0,
-      "free": this.pages,
-      "erased": 0
-    };
-    checkStats(_stats);
-  }
-
-  function test02_usedPages() {
-    for (local i = 1; i <= this.pages; ++i) {
-      // Each file should be place into one page and
-      // page should be marked as used
-      createFile("file_" + i + ".txt", "Some payload");
-
-      // Check that number of free pages was changed
-      _stats.used += 1;
-      _stats.free -= 1;
-      checkStats(_stats);
+    function checkStats(stats) {
+        local s = sffs._fat.getStats();
+        assertDeepEqual(stats, s);
     }
-  }
 
-  function test03_usedPages() {
-    for (local i = 1; i <= this.pages; ++i) {
-      // Each file should free one page and mark it as erased
-      this.sffs.eraseFile("file_" + i + ".txt");
-
-      // Check that number of free pages was changed
-      _stats.erased += 1;
-      _stats.used -= 1;
-      checkStats(_stats);
+    function test01_afterErase() {
+        _stats = {
+            "bad": 0,
+            "used": 0,
+            "free": pages,
+            "erased": 0
+        };
+        checkStats(_stats);
     }
-  }
 
-  function test04_onePageGarbageCollection() {
-    sffs.gc(1);
-    _stats.free += 1;
-    _stats.erased -= 1;
-    checkStats(_stats);
-  }
+    function test02_usedPages() {
+        for (local i = 1; i <= pages; ++i) {
+            // Each file should be place into one page and
+            // page should be marked as used
+            createFile("file_" + i + ".txt", "Some payload");
 
-  function test05_reuseOfFreeSpace() {
-    createFile("file_1.txt", "some payload");
-
-    _stats.used += 1;
-    _stats.free -= 1;
-    checkStats(_stats);
-  }
-
-  // Check GC behavior on all "erased"-marked
-  // pages with threshold one
-  function test06_autoGarbageCollection() {
-    sffs.setAutoGc(1);
-    createFile("file_2.txt", "some payload");
-
-    // GC should clean 2 pages
-    // one for a new file and one for future
-    _stats.used += 1;
-    _stats.free += 1
-    _stats.erased -= 2;
-    checkStats(_stats);
-  }
-
-  //
-  // Check use-case when newly recorded file
-  // takes 2 pages and auto gc free
-  // 2*threshold pages
-  function test07_autoGarbageCollection2() {
-    sffs.setAutoGc(1);
-    local file = this.sffs.open("file_3.txt", "w");
-    // write more then 4KB data
-    for (local i = 0; i < 200; ++i)
-      file.write("01234567890123456789012340");
-    file.close();
-
-    _stats.used += 2;
-    _stats.erased -= 2;
-    checkStats(_stats);
-  }
-
-  // Check that erase method does not
-  // mark free sectors
-  //
-  // Note: AutoGC do nothing on file erase
-  //
-  function test08_eraseFiles() {
-    sffs.eraseFiles();
-
-    _stats.used = 0;
-    _stats.erased = pages - _stats.free;
-    checkStats(_stats);
-  }
-
-  //
-  // precondition - there are number of blocks to erase with AutoGC
-  //
-  function test09_noMoreBlocksToEraseWithAutoGC() {
-    sffs.setAutoGc(1);
-
-    for (local i = 1; i <= this.pages; ++i) {
-      // Each file should be place into one page and
-      // page should be marked as used
-      createFile("file_" + i + ".txt", "Some payload");
-      _stats.used += 1;
-
-      // Check that number of erased and free pages
-      // on each iteration
-      if (_stats.free == 0) {
-        if (_stats.erased < 2) {
-          _stats.free = 0;
-          _stats.erased = 0;
-        } else {
-          _stats.erased -= 2;
-          _stats.free = 1;
+            // Check that number of free pages was changed
+            _stats.used += 1;
+            _stats.free -= 1;
+            checkStats(_stats);
         }
-      } else {
-        _stats.free -= 1;
-      }
-
-      checkStats(_stats);
     }
-  }
 
-  //
-  // Recover to the initial state
-  //
-  function test10_eraseAll() {
-    sffs.eraseAll();
-    _stats = {
-      "bad": 0,
-      "used": 0,
-      "free": this.pages,
-      "erased": 0
-    };
-    checkStats(_stats);
-  }
+    function test03_usedPages() {
+        for (local i = 1; i <= pages; ++i) {
+            // Each file should free one page and mark it as erased
+            sffs.eraseFile("file_" + i + ".txt");
 
-  // TBD: Check that autoGC happens via random algorithm too
+            // Check that number of free pages was changed
+            _stats.erased += 1;
+            _stats.used -= 1;
+            checkStats(_stats);
+        }
+    }
 
+    function test04_onePageGarbageCollection() {
+        sffs.gc(1);
+        _stats.free += 1;
+        _stats.erased -= 1;
+        checkStats(_stats);
+    }
+
+    function test05_reuseOfFreeSpace() {
+        createFile("file_1.txt", "some payload");
+
+        _stats.used += 1;
+        _stats.free -= 1;
+        checkStats(_stats);
+    }
+
+    // Check GC behavior on all "erased"-marked
+    // pages with threshold one
+    function test06_autoGarbageCollection() {
+        sffs.setAutoGc(1);
+        createFile("file_2.txt", "some payload");
+
+        // GC should clean 2 pages
+        // one for a new file and one for future
+        _stats.used += 1;
+        _stats.free += 1
+        _stats.erased -= 2;
+        checkStats(_stats);
+    }
+
+    //
+    // Check use-case when newly recorded file
+    // takes 2 pages and auto gc free
+    // 2*threshold pages
+    function test07_autoGarbageCollection2() {
+        sffs.setAutoGc(1);
+        local file = sffs.open("file_3.txt", "w");
+        // write more then 4KB data
+        for (local i = 0; i < 200; ++i)
+            file.write("01234567890123456789012340");
+        file.close();
+
+        _stats.used += 2;
+        _stats.erased -= 2;
+        checkStats(_stats);
+    }
+
+    // Check that erase method does not
+    // mark free sectors
+    //
+    // Note: AutoGC do nothing on file erase
+    //
+    function test08_eraseFiles() {
+        sffs.eraseFiles();
+
+        _stats.used = 0;
+        _stats.erased = pages - _stats.free;
+        checkStats(_stats);
+    }
+
+    //
+    // precondition - there are number of blocks to erase with AutoGC
+    //
+    function test09_noMoreBlocksToEraseWithAutoGC() {
+        sffs.setAutoGc(1);
+
+        for (local i = 1; i <= pages; ++i) {
+            // Each file should be place into one page and
+            // page should be marked as used
+            createFile("file_" + i + ".txt", "Some payload");
+            _stats.used += 1;
+
+            // Check that number of erased and free pages
+            // on each iteration
+            if (_stats.free == 0) {
+                if (_stats.erased < 2) {
+                    _stats.free = 0;
+                    _stats.erased = 0;
+                } else {
+                    _stats.erased -= 2;
+                    _stats.free = 1;
+                }
+            } else {
+                _stats.free -= 1;
+            }
+
+            checkStats(_stats);
+        }
+    }
+
+    //
+    // Recover to the initial state
+    //
+    function test10_eraseAll() {
+        sffs.eraseAll();
+        _stats = {
+            "bad": 0,
+            "used": 0,
+            "free": pages,
+            "erased": 0
+        };
+        checkStats(_stats);
+    }
 }

--- a/tests/SffsMarkedBlocks.device.test.nut
+++ b/tests/SffsMarkedBlocks.device.test.nut
@@ -1,0 +1,175 @@
+// MIT License
+//
+// Copyright 2017 Electric Imp
+//
+// SPDX-License-Identifier: MIT
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO
+// EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES
+// OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+// ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+
+@include __PATH__ + "/BaseSFFS.device.nut"
+
+class SffsMarkedBlocks extends BaseSffsTestCase {
+  _stats = null;
+
+  function checkStats(stats) {
+    local s = this.sffs._fat.getStats();
+    this.assertDeepEqual(stats, s);
+  }
+
+  function test01_afterErase() {
+    _stats = {
+      "bad": 0,
+      "used": 0,
+      "free": this.pages,
+      "erased": 0
+    };
+    checkStats(_stats);
+  }
+
+  function test02_usedPages() {
+    for (local i = 1; i <= this.pages; ++i) {
+      // Each file should be place into one page and
+      // page should be marked as used
+      createFile("file_" + i + ".txt", "Some payload");
+
+      // Check that number of free pages was changed
+      _stats.used += 1;
+      _stats.free -= 1;
+      checkStats(_stats);
+    }
+  }
+
+  function test03_usedPages() {
+    for (local i = 1; i <= this.pages; ++i) {
+      // Each file should free one page and mark it as erased
+      this.sffs.eraseFile("file_" + i + ".txt");
+
+      // Check that number of free pages was changed
+      _stats.erased += 1;
+      _stats.used -= 1;
+      checkStats(_stats);
+    }
+  }
+
+  function test04_onePageGarbageCollection() {
+    sffs.gc(1);
+    _stats.free += 1;
+    _stats.erased -= 1;
+    checkStats(_stats);
+  }
+
+  function test05_reuseOfFreeSpace() {
+    createFile("file_1.txt", "some payload");
+
+    _stats.used += 1;
+    _stats.free -= 1;
+    checkStats(_stats);
+  }
+
+  // Check GC behavior on all "erased"-marked
+  // pages with threshold one
+  function test06_autoGarbageCollection() {
+    sffs.setAutoGc(1);
+    createFile("file_2.txt", "some payload");
+
+    // GC should clean 2 pages
+    // one for a new file and one for future
+    _stats.used += 1;
+    _stats.free += 1
+    _stats.erased -= 2;
+    checkStats(_stats);
+  }
+
+  //
+  // Check use-case when newly recorded file
+  // takes 2 pages and auto gc free
+  // 2*threshold pages
+  function test07_autoGarbageCollection2() {
+    sffs.setAutoGc(1);
+    local file = this.sffs.open("file_3.txt", "w");
+    // write more then 4KB data
+    for (local i = 0; i < 200; ++i)
+      file.write("01234567890123456789012340");
+    file.close();
+
+    _stats.used += 2;
+    _stats.erased -= 2;
+    checkStats(_stats);
+  }
+
+  // Check that erase method does not
+  // mark free sectors
+  //
+  // Note: AutoGC do nothing on file erase
+  //
+  function test08_eraseFiles() {
+    sffs.eraseFiles();
+
+    _stats.used = 0;
+    _stats.erased = pages - _stats.free;
+    checkStats(_stats);
+  }
+
+  //
+  // precondition - there are number of blocks to erase with AutoGC
+  //
+  function test09_noMoreBlocksToEraseWithAutoGC() {
+    sffs.setAutoGc(1);
+
+    for (local i = 1; i <= this.pages; ++i) {
+      // Each file should be place into one page and
+      // page should be marked as used
+      createFile("file_" + i + ".txt", "Some payload");
+      _stats.used += 1;
+
+      // Check that number of erased and free pages
+      // on each iteration
+      if (_stats.free == 0) {
+        if (_stats.erased < 2) {
+          _stats.free = 0;
+          _stats.erased = 0;
+        } else {
+          _stats.erased -= 2;
+          _stats.free = 1;
+        }
+      } else {
+        _stats.free -= 1;
+      }
+
+      checkStats(_stats);
+    }
+  }
+
+  //
+  // Recover to the initial state
+  //
+  function test10_eraseAll() {
+    sffs.eraseAll();
+    _stats = {
+      "bad": 0,
+      "used": 0,
+      "free": this.pages,
+      "erased": 0
+    };
+    checkStats(_stats);
+  }
+
+  // TBD: Check that autoGC happens via random algorithm too
+
+}


### PR DESCRIPTION
- Add tests for SPIFlashFileSystem library
- Fix for the README documentation for the #20 
- Fix for the #22 
- Fix for the #21 
- Change seek position to 0 for the File.read() blob
- Fix the BAD block detection mechanism of the FAT.scan() method, to prevent mark erased blocks as BAD