### PR TITLE
allocate blob with size to avoid reallocations in read

### DIFF
--- a/SPIFlashFileSystem.device.lib.nut
+++ b/SPIFlashFileSystem.device.lib.nut
@@ -531,11 +531,11 @@ class SPIFlashFileSystem {
         // Get the file
         local file = _fat.get(fileId);
 
-        // Create the result object
-        local result = blob();
-
         // Fix the default length to everything
         if (len == null) len = file.sizeTotal - start;
+
+        // Create the result object
+        local result = blob(len);
 
         // find the initial address
         local next = start, togo = len, pos = 0, page = null, size = null;


### PR DESCRIPTION
Memory is being reallocated multiple times during writing to the result blob thus being inefficient in memory usage. This results in out-of-memory for a large file. Allocating the result blob to the required size would avoid reallocations.